### PR TITLE
microsoft-agent-framework: rewrite guide, add multi-agent + Foundry hosted-agent examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__
 .bedrock_agentcore
 _antora-staging/
 _generated/
+
+# Bicep build artifact (az bicep build output)
+microsoft-foundry/infra/infra/main.json

--- a/microsoft-agent-framework/README.md
+++ b/microsoft-agent-framework/README.md
@@ -1,150 +1,66 @@
-# Microsoft Agent Framework + Neo4j Integration
+# Microsoft Agent Framework + Neo4j
 
-Microsoft Agent Framework is Microsoft's open-source SDK for building AI agents in .NET and Python. Agents can invoke external tools through a standardized interface, whether those tools are local functions, REST APIs, or MCP servers. They can form workflows where multiple specialized agents collaborate on complex tasks. The framework runs locally for development and integrates with Microsoft Foundry for production deployment with tracing and metrics.
+Microsoft Agent Framework is Microsoft's open-source SDK for building production AI agents in Python and .NET — single agents, multi-agent workflows, and hosted-agent deployment.
+Neo4j is the graph database and knowledge layer that grounds those agents in connected enterprise data — relationships, hierarchies, and multi-hop paths the model can actually reason over.
 
-The architecture stays flexible around data access. Custom tools can query databases directly. MCP servers expose data capabilities through a standard protocol. Context providers inject information automatically before each LLM call. Pick the pattern that fits your constraints.
+Better together: Agent Framework gives you agents that **collaborate**. Neo4j gives those agents **shaped, connected context** instead of flattened retrieval.
 
----
+> Agent Framework is cross-vendor — Azure OpenAI, OpenAI, Anthropic, local models, and more. Both examples below use the Microsoft Foundry deployment from [`../microsoft-foundry/`](../microsoft-foundry/) — the local example calls the project endpoint directly, the hosted example registers a containerised agent against the same project. One deployment, one `.env`, both use cases.
 
-## Neo4j Integration Patterns
+## Why multi-agent + graph
 
-There are four patterns for connecting Microsoft Agent Framework agents to Neo4j. Each reflects a different philosophy about where database logic lives and how much the agent controls directly.
+Investment research is multi-step: discover, profile, traverse the network, read the news, synthesize. A single fat agent with twenty tools loses focus — splitting it into a Database agent and an Analyst produces sharper results, and Agent Framework makes that composition trivial: `coordinator.tools = [db.as_tool(), analyst.as_tool()]`.
 
-![Neo4j and Microsoft Agent Framework Integration Patterns](https://dist.neo4j.com/wp-content/uploads/20251216060626/neo4j-integration-patterns.png)
+## Architecture
 
-### Direct SDK Integration
-
-Write custom tools using the official Neo4j drivers. The agent calls your function, your code executes Cypher, and you control exactly what comes back.
-
-This pattern gives you the most control over what the LLM sees. You can filter results, reshape data, handle errors with custom logic, and summarize large result sets before they consume tokens. The tradeoff is maintenance: your integration code is tightly coupled to both the Neo4j driver version and your agent's tool interface.
-
-#### Demo: GraphRAG Contract Review Agents
-
-Christian Glessner (Microsoft MVP) built a contract analysis system on this pattern. Contracts, organizations, clauses, and jurisdictions exist as nodes in a knowledge graph. The agent combines structured Cypher queries with vector search to answer compliance questions across document sets.
-
-A user asks: "Which contracts reference GDPR and involve suppliers in Germany?" The agent's custom tool executes a Cypher query that matches Contract nodes linked to Clause nodes containing GDPR references, then traverses to Organization nodes filtered by jurisdiction. The tool formats the results as a structured response before the LLM generates its answer. No raw JSON parsing in the prompt.
-
-**Source:** [GraphRAG Contract Agents](https://iloveagents.ai/agent-framework-graphrag-neo4j)
-
----
-
-### MCP Server Integration
-
-Run a Neo4j MCP server as a separate process. The agent connects to it like any other MCP tool provider. The server exposes capabilities like `read_cypher` and `get_schema` through the standard protocol.
-
-This pattern separates data access from agent logic. The same MCP server configuration works whether your agent runs locally during development or in Azure for production. Swap the LLM, change the agent framework, the data layer stays constant. The cost is operational: you need to run and maintain the MCP server alongside your agent.
-
-#### Demo: Graph Database Detective
-
-Jose Luis Latorre (Microsoft AI MVP) built an investigative agent that connects to Neo4j Aura via MCP. The graph contains the POLE dataset: persons, objects, locations, and events from crime investigations.
-
-The agent adopts the persona of a Golden Age detective. When a user asks about connections between suspects and crime scenes, the agent calls the MCP server's Cypher tool to traverse the graph. The MCP server executes the query and returns results. The agent then narrates findings in character, turning graph traversals into detective monologues. The persona choice is deliberate — it demonstrates how agent personality and data access remain cleanly separated when using MCP.
-
-**Source:** [Graph Database Detective](https://github.com/joslat/neo4j-agent-framework-exploration)
-
----
-
-### HTTP Query API
-
-Treat Neo4j as a REST endpoint. Send Cypher in POST request bodies, receive JSON responses. No driver installation required.
-
-This pattern works in constrained environments where you cannot install binary dependencies — serverless functions, restricted containers, browser-based agents. Latency is higher than the Bolt protocol and the JSON responses can be verbose, but the simplicity is hard to beat for lightweight use cases.
-
-#### Demo: Sovereign AI Knowledge Base
-
-Matthias Buchhorn Roth (Sopra Steria) built a RAG solution for regulated environments. The graph holds regulations, legal documents, and operational procedures. The system runs in both cloud and air-gapped deployments.
-
-In air-gapped scenarios, installing and maintaining driver dependencies becomes a logistics problem. HTTP calls to a local Neo4j instance sidestep that entirely. The agent queries the regulation graph through REST, combines results with BitNet-based local inference, and produces citation-rich answers. Auditors can trace every response back to specific regulatory nodes in the graph.
-
----
-
-### Context Provider Integration
-
-Context providers inject information into the conversation before each LLM call. The agent does not explicitly request data — the provider searches Neo4j automatically, enriches results through graph traversal, and merges context into the prompt.
-
-The Neo4j Context Provider builds on the `neo4j-graphrag-python` library, which provides `VectorRetriever` for semantic similarity, `HybridRetriever` for combined vector and fulltext search, and `VectorCypherRetriever` for vector search followed by graph traversal. The context provider wraps these retrievers and hooks them into the Microsoft Agent Framework lifecycle.
-
-Configuration is minimal. You specify an index name, choose a search type, and optionally provide a Cypher retrieval query for graph enrichment:
-
-```python
-from neo4j_context_provider import Neo4jContextProvider
-
-provider = Neo4jContextProvider(
-    uri="neo4j+s://your-instance.databases.neo4j.io",
-    username="neo4j",
-    password="your-password",
-    index_name="maintenance_events",
-    index_type="fulltext",  # or "vector"
-    top_k=5,
-    retrieval_query="""
-        MATCH (node)<-[:HAS_EVENT]-(comp:Component)
-              <-[:HAS_COMPONENT]-(sys:System)
-              <-[:HAS_SYSTEM]-(aircraft:Aircraft)
-        RETURN node.fault AS fault,
-               node.corrective_action AS corrective_action,
-               aircraft.model AS aircraft_model,
-               sys.name AS system_name
-    """
-)
+```mermaid
+flowchart LR
+    user["User"] --> coord["Coordinator agent<br/>(FoundryChatClient)"]
+    coord -->|as_tool| db["Database agent<br/>(10 Neo4j function tools)"]
+    coord -->|as_tool| analyst["Analyst agent<br/>(synthesis only)"]
+    db -->|neo4j Bolt driver| neo4j[("Neo4j Aura<br/>or self-managed")]
+    coord -.model.-> foundry["Foundry project<br/>(../microsoft-foundry/)"]
 ```
 
-The `index_type` parameter determines which retriever the provider uses internally. Set it to `"fulltext"` for keyword-based BM25 matching or `"vector"` for semantic similarity search. The `retrieval_query` runs after the initial search, traversing from matched nodes through the graph to pull in related context.
+Both examples implement the same multi-agent graph. The local example runs your code; the hosted example runs that code inside Foundry's managed runtime.
 
-[Context Provider Architecture Details](https://github.com/neo4j-labs/neo4j-maf-provider)
+## Quick start
 
-#### Demo: Aircraft Maintenance and Flight Operations
+```bash
+az login
+cd microsoft-foundry/infra && ./deploy.sh    # one-time, opt in to Foundry
+cd ../../microsoft-agent-framework/examples/multi-agent && uv run multi_agent_neo4j.py
+```
 
-The Neo4j Context Provider demo models maintenance events and flight delays as a knowledge graph. When a user asks about recurring faults on a specific aircraft type, the provider's `invoking()` method fires before the LLM processes the message.
+Defaults connect to the public `companies` Neo4j demo graph and use the Foundry project provisioned by `deploy.sh`.
 
-The provider runs a fulltext search against the maintenance index using the user's question. Results come back as maintenance event nodes. The configured retrieval query then traverses from those events through component and system relationships to aircraft nodes, pulling in fault codes, corrective actions, and affected systems. This enriched context merges into the prompt automatically.
+## Examples
 
-The flight delays agent works similarly. Questions about delay patterns trigger searches against flight data, with graph traversal expanding from delay nodes through flights to airports and routes. The LLM receives a connected view of the data without the agent ever making an explicit tool call.
+| Example | What it shows | Folder |
+| --- | --- | --- |
+| **Multi-agent (local)** | Coordinator + Database + Analyst via `as_tool()`, function tools to Neo4j | [`examples/multi-agent`](./examples/multi-agent/) |
+| **Foundry-hosted multi-agent** | Same multi-agent graph packaged as a Foundry hosted agent | [`examples/foundry-hosted`](./examples/foundry-hosted/) |
 
-**Source:** [Neo4j Context Provider with Flight Demo](https://github.com/neo4j-labs/neo4j-maf-provider)
+## Why host on Foundry?
 
----
+Hosted agents in Foundry Agent Service let you ship the same Agent Framework code to a managed runtime. From the [official hosted-agents concepts page](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents):
 
-## Choosing Your Integration Pattern
+- **Bring your own code** — Agent Framework, LangGraph, Semantic Kernel, or custom; the platform doesn't care.
+- **Dedicated agent identity** — a Microsoft Entra ID is auto-created at deploy and used by your agent at runtime to call models, tools, and downstream Azure services.
+- **Per-session VM-isolated sandboxes** — `$HOME` and `/files` persist across turns and idle (15-min idle timeout, 30-day session lifetime).
+- **Versioning** — immutable agent versions with weighted traffic split for canary and blue-green rollouts.
+- **Scale-to-zero** — the platform handles container lifecycle, scaling, and observability via Application Insights.
+- **Foundry portal integration** — playground, version management, and traces, with no extra wiring.
 
-**Start with the context provider** if you want graph-aware agents running quickly. Configure an index, point at your Neo4j instance, and the framework handles the rest. Add a retrieval query later when you need graph traversal beyond the initial search results.
+## References
 
-**Move to direct SDK integration** when you need precise control over what the LLM sees. Complex business logic, token budget constraints, or custom result formatting all push toward this pattern. The tool can filter, summarize, and structure graph results before they ever reach the prompt.
+### Microsoft Agent Framework
+- [Microsoft Agent Framework overview](https://learn.microsoft.com/agent-framework/overview/)
+- [Microsoft Foundry provider](https://learn.microsoft.com/agent-framework/agents/providers/microsoft-foundry)
+- [Agents as tools](https://learn.microsoft.com/agent-framework/journey/agents-as-tools)
+- [Hosted agents concepts](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents)
+- [Hosted agents quickstart](https://learn.microsoft.com/azure/foundry/agents/quickstarts/quickstart-hosted-agent)
 
-**MCP makes sense** when you want to reuse the same data layer across multiple agents or frameworks. If you expect to swap LLMs or run agents in different environments, the separation MCP provides pays off. Keep the tool count reasonable to avoid bloating the system prompt.
-
-**The HTTP API** fits constrained environments where installing drivers is not an option — serverless functions, sandboxed containers, browser-based agents.
-
-Each pattern assumes you already have a graph worth querying. The agent integration is the last mile. Before that comes data modeling, relationship design, and index configuration.
-
----
-
-
-## Resources
-
-### Authors
-- [Christian Glessner](https://www.linkedin.com/in/christian-glessner/)
-- [Jose Luis Latorre](https://www.linkedin.com/in/joslat/)
-- [Matthias Buchhorn-Roth](https://www.linkedin.com/in/mbuchhorn/)
-- [Ryan Knight](https://www.linkedin.com/in/ryanknight/)
-- [Zaid Zaim](https://www.linkedin.com/in/zaidzaim/)
-
-### Open Source Integrations
-- [Neo4j + Microsoft Agent Framework (ma3u)](https://github.com/ma3u/neo4j-agentframework)
-- [Neo4j Context Provider](https://github.com/neo4j-labs/neo4j-maf-provider)
-
-### Community Demos
-- [Graph Database Detective](https://github.com/joslat/neo4j-agent-framework-exploration) — crime investigation with POLE dataset
-- [GraphRAG Contract Agents](https://iloveagents.ai/agent-framework-graphrag-neo4j) — contract compliance analysis
-- [Aircraft Maintenance & Flight Delays](https://github.com/neo4j-labs/neo4j-maf-provider) — context provider demo
-
-### Documentation
-- [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
-- [Neo4j Community](https://community.neo4j.com/)
-
----
-
-## Videos & Tutorials
-
-NODES 2025 — Christian Glessner: Live-Coding Graph-Native Agents: Neo4j AuraDB + Microsoft Agent Framework in Action
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aJY7Sm5vtko" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+### Neo4j
+- [Neo4j Knowledge Graph](https://neo4j.com/product/) — graph database and knowledge layer for AI
+- [Neo4j Python driver](https://neo4j.com/docs/python-manual/current/)

--- a/microsoft-agent-framework/examples/foundry-hosted/.dockerignore
+++ b/microsoft-agent-framework/examples/foundry-hosted/.dockerignore
@@ -1,0 +1,10 @@
+.azure
+.env
+.venv
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.git
+.gitignore
+README.md

--- a/microsoft-agent-framework/examples/foundry-hosted/.env.example
+++ b/microsoft-agent-framework/examples/foundry-hosted/.env.example
@@ -1,0 +1,10 @@
+# Foundry — injected automatically when deployed; set locally for `python main.py`.
+FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
+AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+FOUNDRY_EMBEDDING_DEPLOYMENT_NAME=text-embedding-3-small
+
+# Neo4j — defaults connect to the public companies demo graph.
+NEO4J_URI=neo4j+s://demo.neo4jlabs.com:7687
+NEO4J_DATABASE=companies
+NEO4J_USERNAME=companies
+NEO4J_PASSWORD=companies

--- a/microsoft-agent-framework/examples/foundry-hosted/Dockerfile
+++ b/microsoft-agent-framework/examples/foundry-hosted/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . user_agent/
+WORKDIR /app/user_agent
+
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    else \
+        echo "No requirements.txt found"; \
+    fi
+
+EXPOSE 8088
+
+CMD ["python", "main.py"]

--- a/microsoft-agent-framework/examples/foundry-hosted/README.md
+++ b/microsoft-agent-framework/examples/foundry-hosted/README.md
@@ -1,0 +1,138 @@
+# Foundry-hosted multi-agent — Microsoft Agent Framework + Neo4j
+
+Same multi-agent investment-research graph as [`../multi-agent/`](../multi-agent/) — Coordinator + Database Agent + Analyst Agent — packaged as a [Foundry hosted agent](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents) via [`agent-framework-foundry-hosting`](https://pypi.org/project/agent-framework-foundry-hosting/) (`ResponsesHostServer`). Deployed with the canonical [`azd ai agent init -m`](https://learn.microsoft.com/azure/foundry/agents/quickstarts/quickstart-hosted-agent) flow.
+
+## Why host it?
+
+Hosted agents take the same Agent Framework code you ran locally and put it on Foundry's managed runtime. From the [official concepts page](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents):
+
+- **Bring your own code** — Agent Framework, LangGraph, custom; the platform doesn't care.
+- **Dedicated agent identity** — a Microsoft Entra ID is auto-created at deploy and used by the agent at runtime to call models, tools, and downstream Azure services. No managed-identity wiring.
+- **Per-session VM-isolated sandboxes** — `$HOME` and `/files` persist across turns and idle (15-min idle timeout, 30-day session lifetime).
+- **Versioning** — immutable agent versions with weighted traffic split for canary and blue-green rollouts.
+- **Scale-to-zero** — Foundry handles container lifecycle, scaling, and Application Insights observability.
+- **Foundry portal integration** — playground, version management, and traces, no extra wiring.
+
+## Files in this folder
+
+Flat layout matching the canonical [agent-framework hosted samples](https://github.com/microsoft/agent-framework/tree/main/python/samples/04-hosting/foundry-hosted-agents/responses):
+
+| File | Purpose |
+| --- | --- |
+| `main.py` | The full agent definition (10 `@tool` functions + 3 instructions + Coordinator) plus `ResponsesHostServer().run()`. Self-contained on purpose; [`../multi-agent/multi_agent_neo4j.py`](../multi-agent/multi_agent_neo4j.py) is a parallel near-identical file for local dev. |
+| `requirements.txt` | Python deps (split-package install — see local example README) |
+| `Dockerfile` | `python:3.12-slim`, exposes port 8088 |
+| `.dockerignore` | Excludes `.azure/`, `.env`, `__pycache__/`, etc. |
+| `agent.yaml` | Hosted-agent definition (protocol, resources, env vars) |
+| `agent.manifest.yaml` | Template metadata + model resource — `azd ai agent init -m` reads this |
+| `.env.example` | What to set locally for `python main.py` |
+| `README.md` | This file |
+
+## Deploy
+
+The flow below is the [canonical hosted-agents quickstart](https://learn.microsoft.com/azure/foundry/agents/quickstarts/quickstart-hosted-agent) — Microsoft's recommended path for shipping an Agent Framework agent to Foundry.
+
+### Prerequisites
+
+```bash
+azd ext install azure.ai.agents      # 0.1.27-preview or newer required
+az login
+cd microsoft-foundry/infra && ./deploy.sh    # if you haven't already — provides the Foundry project
+```
+
+`microsoft-foundry/infra/deploy.sh` deploys to Sweden Central by default — a hosted-agents-supported region — so the same project can host this example.
+
+### Deploy
+
+```bash
+# Resolve the Foundry project ID from the microsoft-foundry/ deployment
+PROJECT_ID="$(az resource list \
+  --resource-type 'Microsoft.CognitiveServices/accounts/projects' \
+  --query "[?starts_with(name, 'aif-foundry-neo4j')].id | [0]" -o tsv)"
+
+mkdir my-research-agent && cd my-research-agent
+
+# 1. Scaffold the azd starter (provides infra/main.bicep)
+azd init -t Azure-Samples/azd-ai-starter-basic --location swedencentral
+
+# 2. Add the agent on top, pointing at the existing Foundry project + model
+azd ai agent init \
+  -m https://raw.githubusercontent.com/<owner>/neo4j-agent-integrations/feature/agent-framework/microsoft-agent-framework/examples/foundry-hosted/agent.manifest.yaml \
+  -p "$PROJECT_ID" \
+  -d gpt-4o-mini
+
+# 3. Wire Neo4j (defaults connect to the public companies demo graph) +
+#    the embedding deployment that microsoft-foundry/infra/ provisioned
+azd env set NEO4J_URI                       "neo4j+s://demo.neo4jlabs.com:7687"
+azd env set NEO4J_DATABASE                  "companies"
+azd env set NEO4J_USERNAME                  "companies"
+azd env set NEO4J_PASSWORD                  "companies"
+azd env set FOUNDRY_EMBEDDING_DEPLOYMENT_NAME "text-embedding-3-small"
+
+# 4. Build container, register agent against the existing Foundry project
+azd up
+```
+
+End-to-end takes ~2-3 minutes. `azd up` prints the agent endpoint and a Foundry portal playground link. The hosted runtime lives in the **same Foundry project** as the Neo4j MCP container app — one deployment, both use cases.
+
+> **`-m` takes a file path, not a folder.** Some Microsoft docs suggest a folder works — the CLI rejects it with `"is a directory, not a manifest file"`. Always point at the `agent.manifest.yaml` file (or its raw GitHub URL).
+
+### Test the deployed agent
+
+```bash
+azd ai agent invoke "Research Microsoft's position in the software industry. Gather company profile, recent news, and key relationships, then synthesize an investment outlook."
+```
+
+You'll see a structured report — Executive Summary, Company Profile, Recent Developments, Network table, Risks & Outlook — with every `company_id` and `article_id` cited verbatim from the graph (real IDs like `EFhu1XwygPsKq_UjZtDFwXQ` and `ART11195006745`, not made-up placeholders).
+
+Open the agent in the Foundry portal playground via the link printed by `azd up`.
+
+### Tear down
+
+```bash
+# This removes the agent + ACR provisioned by THIS folder. The shared
+# Foundry account/project from microsoft-foundry/ stays alive — purge
+# (`--purge`) would also delete the shared account, so leave it off.
+azd down --no-prompt
+```
+
+To remove the entire shared deployment as well, run `azd down --purge --no-prompt` from `microsoft-foundry/infra/` afterwards.
+
+## Running locally first (optional sanity check)
+
+Before paying for a deployment, run the same code on your laptop:
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+# edit .env to fill in FOUNDRY_PROJECT_ENDPOINT and AZURE_AI_MODEL_DEPLOYMENT_NAME
+# (the Neo4j defaults already point at the demo graph)
+az login
+python main.py
+```
+
+The server listens on `http://localhost:8088`. In another terminal:
+
+```bash
+curl -X POST http://localhost:8088/responses \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Research Microsoft. Profile, news, relationships, then an investment outlook."}'
+```
+
+You'll see the same multi-agent flow as the local example — Coordinator → Database Agent (multiple Neo4j tool calls) → Analyst Agent — synthesizing a faithful, ID-cited report.
+
+## Security note
+
+Per the official [hosted-agents docs](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents): "Don't put secrets in container images or environment variables. Use managed identities and connections, and store secrets in a managed secret store."
+
+This sample stores Neo4j credentials in `azd env` (which writes them to `.azure/<env>/.env`) for demo-graph simplicity (`companies`/`companies` is public). For BYO Neo4j (Aura), wire credentials through a [Key Vault connection](https://learn.microsoft.com/azure/foundry/how-to/set-up-key-vault-connection) and reference them from `agent.yaml` instead of plain env vars.
+
+## How it differs from `../multi-agent/`
+
+Same agent graph, three differences in `main.py`:
+
+1. **Tool decorator** — every Neo4j function is wrapped in `@tool(approval_mode="never_require")` with `Annotated[..., Field(description=...)]` parameter docs. Hosted agents default to requiring approval for tool calls; we opt out so the multi-agent flow runs unattended.
+2. **Credential** — `DefaultAzureCredential()` (the agent's Microsoft Entra ID at runtime, your `az login` locally), instead of `AzureCliCredential(tenant_id=...)`.
+3. **`default_options={"store": False}`** on the coordinator — the hosting platform owns conversation history; don't double-persist on the OpenAI Responses side.
+
+That's it. The multi-agent composition (Coordinator + Database Agent + Analyst Agent via `as_tool()`) and the anti-hallucination contract (JSON blocks per tool call, raw rows verbatim) are identical.

--- a/microsoft-agent-framework/examples/foundry-hosted/agent.manifest.yaml
+++ b/microsoft-agent-framework/examples/foundry-hosted/agent.manifest.yaml
@@ -1,0 +1,36 @@
+name: neo4j-research-agent-framework
+description: >
+  Microsoft Agent Framework + Neo4j multi-agent investment research agent
+  (coordinator → database + analyst), hosted on Foundry Agent Service.
+metadata:
+  tags:
+    - Agent Framework
+    - Neo4j
+    - Multi-agent
+    - Investment Research
+    - Responses Protocol
+template:
+  name: neo4j-research-agent-framework
+  kind: hosted
+  protocols:
+    - protocol: responses
+      version: 1.0.0
+  environment_variables:
+    - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+      value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"
+    - name: FOUNDRY_EMBEDDING_DEPLOYMENT_NAME
+      value: ${FOUNDRY_EMBEDDING_DEPLOYMENT_NAME}
+    - name: NEO4J_URI
+      value: ${NEO4J_URI}
+    - name: NEO4J_DATABASE
+      value: ${NEO4J_DATABASE}
+    - name: NEO4J_USERNAME
+      value: ${NEO4J_USERNAME}
+    - name: NEO4J_PASSWORD
+      value: ${NEO4J_PASSWORD}
+resources:
+  # gpt-4o-mini matches what microsoft-foundry/infra/deploy.sh provisions, so
+  # the hosted agent reuses the chat model from a shared Foundry project.
+  - kind: model
+    id: gpt-4o-mini
+    name: AZURE_AI_MODEL_DEPLOYMENT_NAME

--- a/microsoft-agent-framework/examples/foundry-hosted/agent.yaml
+++ b/microsoft-agent-framework/examples/foundry-hosted/agent.yaml
@@ -1,0 +1,19 @@
+kind: hosted
+name: neo4j-research-agent-framework
+protocols:
+  - protocol: responses
+    version: 1.0.0
+resources:
+  cpu: "0.5"
+  memory: 1Gi
+environment_variables:
+  - name: NEO4J_URI
+    value: ${NEO4J_URI}
+  - name: NEO4J_DATABASE
+    value: ${NEO4J_DATABASE}
+  - name: NEO4J_USERNAME
+    value: ${NEO4J_USERNAME}
+  - name: NEO4J_PASSWORD
+    value: ${NEO4J_PASSWORD}
+  - name: FOUNDRY_EMBEDDING_DEPLOYMENT_NAME
+    value: ${FOUNDRY_EMBEDDING_DEPLOYMENT_NAME}

--- a/microsoft-agent-framework/examples/foundry-hosted/main.py
+++ b/microsoft-agent-framework/examples/foundry-hosted/main.py
@@ -1,0 +1,381 @@
+# Copyright (c) Neo4j. All rights reserved.
+"""Microsoft Agent Framework + Neo4j: multi-agent investment research,
+packaged as a Foundry hosted agent.
+
+Implements the multi-agent spec from EXAMPLE_AGENT.md — Coordinator delegates
+to a Database Agent (10 typed Neo4j function tools) and an Analyst Agent
+(synthesis only). Wrapped with ResponsesHostServer for Foundry hosted-agent
+deployment. Self-contained on purpose; ../multi-agent/multi_agent_neo4j.py
+is a parallel, near-identical file for the local-dev runtime.
+"""
+
+import asyncio
+import os
+from typing import Annotated
+
+from agent_framework import Agent, tool
+from agent_framework.foundry import FoundryChatClient
+from agent_framework.openai import OpenAIEmbeddingClient
+from agent_framework_foundry_hosting import ResponsesHostServer
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
+from neo4j import GraphDatabase
+from pydantic import Field
+
+load_dotenv()
+
+DB = os.environ.get("NEO4J_DATABASE", "companies")
+driver = None  # initialised in main(); tools reference it via module lookup
+embeddings = None  # OpenAIEmbeddingClient — initialised in main()
+
+
+# Discovery ---------------------------------------------------------------
+
+@tool(approval_mode="never_require")
+def search_companies(
+    search: Annotated[str, Field(description="Free-text query; matches against the entity full-text index.")],
+) -> list[dict]:
+    """Full-text fuzzy search for companies by name. Up to 20 ranked matches with company_id."""
+    rows, _, _ = driver.execute_query("""
+        CALL db.index.fulltext.queryNodes('entity', $search, {limit: 20})
+        YIELD node AS c, score
+        WHERE c:Organization
+        RETURN c.id AS company_id, c.name AS name, c.summary AS summary
+        ORDER BY score DESC
+    """, search=search, database_=DB)
+    return [r.data() for r in rows]
+
+
+@tool(approval_mode="never_require")
+def list_industries() -> list[dict]:
+    """All IndustryCategory names, alphabetical."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (i:IndustryCategory)
+        RETURN i.name AS industry
+        ORDER BY i.name
+    """, database_=DB)
+    return [r.data() for r in rows]
+
+
+@tool(approval_mode="never_require")
+def companies_in_industry(
+    industry: Annotated[str, Field(description="An exact IndustryCategory name (e.g. 'Software Companies').")],
+) -> list[dict]:
+    """Up to ten companies in the given IndustryCategory, with company_id."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (:IndustryCategory {name: $industry})<-[:HAS_CATEGORY]-(c:Organization)
+        RETURN c.id AS company_id, c.name AS name, c.summary AS summary
+        LIMIT 10
+    """, industry=industry, database_=DB)
+    return [r.data() for r in rows]
+
+
+# Profile -----------------------------------------------------------------
+
+@tool(approval_mode="never_require")
+def query_company(
+    company_name: Annotated[str, Field(description="The company's exact name (e.g. 'Microsoft').")],
+) -> dict:
+    """Primary company lookup — returns company_id, name, industries, locations, leadership."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (o:Organization {name: $name})
+        OPTIONAL MATCH (o)-[:HAS_CATEGORY]->(c:IndustryCategory)
+        OPTIONAL MATCH (o)-[:IN_CITY]->(city:City)
+        OPTIONAL MATCH (o)-[:IN_COUNTRY]->(country:Country)
+        OPTIONAL MATCH (o)-[:HAS_CEO]->(ceo:Person)
+        OPTIONAL MATCH (o)-[:HAS_BOARD_MEMBER]->(b:Person)
+        RETURN o.id AS company_id, o.name AS name,
+               collect(DISTINCT c.name)[..5] AS industries,
+               collect(DISTINCT city.name)[..3] + collect(DISTINCT country.name) AS locations,
+               [x IN collect(DISTINCT {name: ceo.name, title: 'CEO'})
+                   + collect(DISTINCT {name: b.name, title: 'Board Member'})
+                 WHERE x.name IS NOT NULL][..6] AS leadership
+    """, name=company_name, database_=DB)
+    return rows[0].data() if rows else {}
+
+
+# Network -----------------------------------------------------------------
+
+@tool(approval_mode="never_require")
+def analyze_relationships(
+    company_name: Annotated[str, Field(description="The company's exact name.")],
+) -> list[dict]:
+    """1-2 hop org-to-org connections (subsidiaries, suppliers, competitors, board, investors).
+    Returns connected orgs with relationship types and distance."""
+    rows, _, _ = driver.execute_query("""
+        MATCH path = (o1:Organization {name: $name})-[*1..2]-(o2:Organization)
+        WHERE o1 <> o2
+        RETURN DISTINCT o2.id AS company_id, o2.name AS organization,
+               [r IN relationships(path) | type(r)] AS relationships,
+               length(path) AS distance
+        ORDER BY distance LIMIT 20
+    """, name=company_name, database_=DB)
+    return [r.data() for r in rows]
+
+
+@tool(approval_mode="never_require")
+def people_at_company(
+    company_id: Annotated[str, Field(description="Internal company_id from query_company / search_companies.")],
+) -> list[dict]:
+    """People associated with a company (by company_id) and their roles (CEO, Board Member, …)."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (c:Organization {id: $id})-[role]-(p:Person)
+        RETURN replace(type(role), 'HAS_', '') AS role,
+               p.name AS person_name,
+               c.id AS company_id, c.name AS company_name
+    """, id=company_id, database_=DB)
+    return [r.data() for r in rows]
+
+
+# News --------------------------------------------------------------------
+
+@tool(approval_mode="never_require")
+async def search_news(
+    company_name: Annotated[str, Field(description="The company's exact name.")],
+    query: Annotated[str, Field(description="Free-text query embedded for semantic similarity search over article chunks.")],
+) -> list[dict]:
+    """Vector-search news about a company. Embeds `query` via the Foundry embedding
+    deployment (text-embedding-3-small, 1536d), then runs cosine similarity over
+    Chunks restricted to articles that MENTION the company. Returns up to 5 hits
+    with article_id, title, date, sentiment, the matched chunk text, and the score."""
+    result = await embeddings.get_embeddings([query])
+    vector = result[0].vector
+    # The 'news' vector index would return top-K across ALL chunks before our
+    # company filter — most of which won't mention this company. Compute cosine
+    # similarity directly over the pre-filtered company-mentioning chunks
+    # instead. Cheap at this scale (a few thousand chunks per major company).
+    # Off-thread the sync neo4j call so we don't block the event loop while
+    # the hosted server has concurrent requests in flight.
+    def _query() -> list[dict]:
+        rows, _, _ = driver.execute_query("""
+            MATCH (a:Article)-[:MENTIONS]->(:Organization {name: $name})
+            MATCH (a)-[:HAS_CHUNK]->(c:Chunk)
+            WHERE c.embedding IS NOT NULL
+            WITH a, c, vector.similarity.cosine(c.embedding, $embedding) AS score
+            RETURN a.id AS article_id, a.title AS title, toString(a.date) AS date,
+                   a.sentiment AS sentiment, c.text AS text, score
+            ORDER BY score DESC LIMIT 5
+        """, name=company_name, embedding=vector, database_=DB)
+        return [r.data() for r in rows]
+    return await asyncio.to_thread(_query)
+
+
+@tool(approval_mode="never_require")
+def articles_in_month(
+    date: Annotated[str, Field(description="Start of a calendar month, yyyy-mm-dd (e.g. 2022-06-01).")],
+) -> list[dict]:
+    """Articles in the month starting at the given yyyy-mm-dd date."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (a:Article)
+        WHERE date($date) <= date(a.date) < date($date) + duration('P1M')
+        RETURN a.id AS article_id, a.author AS author, a.title AS title,
+               toString(a.date) AS date, a.sentiment AS sentiment
+        ORDER BY a.date DESC LIMIT 25
+    """, date=date, database_=DB)
+    return [r.data() for r in rows]
+
+
+@tool(approval_mode="never_require")
+def get_article(
+    article_id: Annotated[str, Field(description="Article id from search_news / articles_in_month.")],
+) -> dict:
+    """Full article body, summary, sentiment, joined from chunks."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (a:Article {id: $id})-[:HAS_CHUNK]->(c:Chunk)
+        WITH a, c ORDER BY id(c) ASC
+        WITH a, collect(c.text) AS contents
+        RETURN a.id AS article_id, a.author AS author, a.title AS title,
+               toString(a.date) AS date, a.summary AS summary,
+               a.siteName AS site, a.sentiment AS sentiment,
+               apoc.text.join(contents, ' ') AS content
+    """, id=article_id, database_=DB)
+    return rows[0].data() if rows else {}
+
+
+@tool(approval_mode="never_require")
+def companies_in_article(
+    article_id: Annotated[str, Field(description="Article id from search_news / articles_in_month.")],
+) -> list[dict]:
+    """Companies mentioned in a specific article (by article_id)."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (a:Article {id: $id})-[:MENTIONS]->(c:Organization)
+        RETURN c.id AS company_id, c.name AS name, c.summary AS summary
+    """, id=article_id, database_=DB)
+    return [r.data() for r in rows]
+
+
+DATABASE_TOOLS = [
+    search_companies, list_industries, companies_in_industry,
+    query_company,
+    analyze_relationships, people_at_company,
+    search_news, articles_in_month, get_article, companies_in_article,
+]
+
+
+# Agent instructions ------------------------------------------------------
+
+DATABASE_INSTRUCTIONS = """\
+You are a data-access agent over a Neo4j knowledge graph of companies (Organization),
+people (Person), industries (IndustryCategory), locations (City, Country), and
+articles (Article). Other agents call you to fetch facts.
+
+Tools (read-only):
+  Discovery: search_companies, list_industries, companies_in_industry
+  Profile:   query_company
+  Network:   analyze_relationships, people_at_company
+  News:      search_news (vector — needs a query string), articles_in_month, get_article, companies_in_article
+
+Output protocol — STRICT, machine-readable
+  Your reply is consumed by another agent, not a human. Output ONE fenced
+  ```json``` block per tool call you made, with this exact shape:
+
+    ```json
+    {
+      "tool": "<tool name>",
+      "args": { ... what you passed in ... },
+      "rows": [ ... the tool result, verbatim, every field ... ]
+    }
+    ```
+
+  Rules
+  • Include EVERY field the tool returned — `company_id`, `article_id`, `title`,
+    `date`, `sentiment`, `relationships`, `distance`, `industries`, `locations`,
+    `leadership`, etc. Real IDs look like `EIsFKrN_ZNLSWsvxdQfWutQ` and
+    `ART11195006745`; never shorten or substitute.
+  • If a tool returns no rows, set `"rows": []`.
+  • No prose. No summary. No headings. Only the JSON blocks, one per call.
+  • Never reason from prior knowledge — the only valid content is what the
+    tools returned this turn.
+"""
+
+ANALYST_INSTRUCTIONS = """\
+You are an investment-research analyst. Your input is one or more ```json```
+blocks the database agent gathered. Each block has `tool`, `args`, and `rows`.
+Synthesize a concise investment-research report from those rows — and only
+those rows.
+
+Report structure
+  Executive Summary   — 2-3 sentences with the headline finding.
+  Company Profile     — industries, locations, leadership; one short paragraph.
+                        Cite the `company_id` once.
+  Recent Developments — bullet list. Each bullet MUST start with the real
+                        `article_id` from the rows, then the `title`, `date`,
+                        and `sentiment`.
+  Network             — Markdown table with columns: `company_id`,
+                        `organization`, `relationships`, `distance` — copied
+                        from the rows verbatim.
+  Risks & Outlook     — what the data suggests, and what's missing.
+
+Rules — STRICT, no exceptions
+  • Every `company_id`, `article_id`, `title`, and relationship type in your
+    report must appear verbatim in the input rows. Real IDs look like
+    `EIsFKrN_ZNLSWsvxdQfWutQ` and `ART11195006745`.
+  • If you find yourself writing a short numeric ID like "101" or "201", or a
+    generic name ("Strategic Partner", "AWS partnership") that isn't in the
+    rows, STOP — that is hallucination. Re-read the JSON blocks.
+  • If a section has no supporting rows, write "(no data)" — never pad.
+  • Insight is welcome in Risks & Outlook only, and only insight that follows
+    directly from the rows.
+"""
+
+COORDINATOR_INSTRUCTIONS = """\
+You orchestrate investment research. You delegate to two specialists:
+
+  database_agent — fetches rows from the graph. Returns one or more
+                   ```json``` blocks per call, each with `tool`, `args`,
+                   and `rows`.
+  analyst        — turns those JSON blocks into an investment-research report.
+
+Workflow
+  1. Call `database_agent` once per facet: company profile, peers, recent
+     news, relationships, key people. Each call should be a focused request
+     like "query_company('Microsoft')" or
+     "companies_in_industry('Software Companies')".
+  2. CONCATENATE every `database_agent` response verbatim into one string
+     and pass that string as the `task` to `analyst`. The analyst MUST see
+     the raw JSON blocks — never strip them down to bare IDs or summaries.
+  3. Return the analyst's report verbatim — don't paraphrase or re-summarize.
+
+Never query the graph yourself. Never write the report yourself. Faithful
+relaying is your job.
+"""
+
+
+# Server ------------------------------------------------------------------
+
+def main() -> None:
+    project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+
+    global driver, embeddings
+    driver = GraphDatabase.driver(
+        os.environ["NEO4J_URI"],
+        auth=(os.environ.get("NEO4J_USERNAME", "companies"),
+              os.environ.get("NEO4J_PASSWORD", "companies")),
+    )
+
+    # Single sync DefaultAzureCredential reused by both clients. Sync is fine
+    # here — both clients accept TokenCredential | AsyncTokenCredential, and
+    # the sync variant has no async session to leak across the long-running
+    # ResponsesHostServer process.
+    credential = DefaultAzureCredential()
+
+    # OpenAIEmbeddingClient is the canonical agent-framework path for Entra-ID
+    # auth against an Azure OpenAI / Foundry endpoint. See microsoft/agent-framework:
+    # python/samples/02-agents/embeddings/openai_embeddings_on_azure.py
+    embeddings = OpenAIEmbeddingClient(
+        model=os.environ.get("FOUNDRY_EMBEDDING_DEPLOYMENT_NAME", "text-embedding-3-small"),
+        azure_endpoint=project_endpoint.split("/api/")[0],
+        credential=credential,
+    )
+
+    client = FoundryChatClient(
+        project_endpoint=project_endpoint,
+        model=os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"],
+        credential=credential,
+    )
+
+    # Names match EXAMPLE_AGENT.md — `database_agent`, `analyst`,
+    # `coordinator` — so the trace and instructions read consistently
+    # across the spec, the code, and the model's tool-call surface.
+    database_agent = Agent(
+        client=client,
+        name="database_agent",
+        instructions=DATABASE_INSTRUCTIONS,
+        tools=DATABASE_TOOLS,
+    )
+    analyst_agent = Agent(
+        client=client,
+        name="analyst",
+        instructions=ANALYST_INSTRUCTIONS,
+    )
+    coordinator = Agent(
+        client=client,
+        name="coordinator",
+        instructions=COORDINATOR_INSTRUCTIONS,
+        tools=[
+            database_agent.as_tool(
+                name="database_agent",
+                description="Fetch company / news / relationship / people rows from the Neo4j graph. Returns JSON blocks with raw rows.",
+                arg_name="task",
+                arg_description="What to fetch — be specific (which company, what aspect).",
+            ),
+            analyst_agent.as_tool(
+                name="analyst",
+                description="Synthesize JSON rows from `database_agent` into an investment-research report.",
+                arg_name="task",
+                arg_description="Concatenated JSON blocks the database agent returned, plus the analysis goal.",
+            ),
+        ],
+        # The Foundry hosting infrastructure manages conversation history;
+        # don't double-persist on the OpenAI Responses side.
+        default_options={"store": False},
+    )
+
+    try:
+        ResponsesHostServer(coordinator).run()
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/microsoft-agent-framework/examples/foundry-hosted/requirements.txt
+++ b/microsoft-agent-framework/examples/foundry-hosted/requirements.txt
@@ -1,0 +1,12 @@
+# The PyPI meta-package "agent-framework" ships an empty __init__.py that
+# shadows the real exports from "agent-framework-core" — pin the split
+# packages directly.
+agent-framework-core>=1.2.1
+agent-framework-foundry>=1.2.1
+agent-framework-foundry-hosting
+agent-framework-openai>=1.2.1
+aiohttp
+azure-identity
+neo4j>=5
+pydantic
+python-dotenv

--- a/microsoft-agent-framework/examples/multi-agent/README.md
+++ b/microsoft-agent-framework/examples/multi-agent/README.md
@@ -1,0 +1,85 @@
+# Microsoft Agent Framework + Neo4j
+
+[Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) is Microsoft's open-source SDK for building production AI agents in Python and .NET — single agents, multi-agent workflows, and hosted-agent deployment.
+Neo4j is the graph database and knowledge layer that grounds those agents in connected enterprise data.
+
+This example wires them together as a multi-agent investment-research assistant: a **Coordinator** delegates to a **Database** agent (queries Neo4j) and an **Analyst** (synthesizes a report). One uv-runnable file. Reads `microsoft-foundry/.env` for the Foundry endpoint and Neo4j credentials.
+
+Tool names and return shapes follow the [`EXAMPLE_AGENT.md`](../../../EXAMPLE_AGENT.md) spec ("Industry Research Agent").
+
+## When to pick this path
+
+- You want to see how Agent Framework composes multiple agents.
+- A single fat agent with twenty tools loses focus — splitting work into a Database agent and an Analyst produces sharper, more grounded output.
+- Function tools talk to Neo4j directly via the Bolt driver — no MCP server, no extra hop.
+
+## Quick start
+
+```bash
+az login
+cd microsoft-foundry/infra && ./deploy.sh    # one-time, opt in to Foundry
+cd ../../microsoft-agent-framework/examples/multi-agent && uv run multi_agent_neo4j.py
+```
+
+`uv` reads the inline `# /// script` deps at the top of `multi_agent_neo4j.py` and runs. The script reads `microsoft-foundry/.env` for the Foundry endpoint, Azure tenant, and Neo4j credentials.
+
+## The three agents
+
+```mermaid
+flowchart LR
+    user["User"] --> coord
+    subgraph agents["Multi-agent system"]
+        coord["Coordinator Agent<br/>(delegates)"]
+        db["Database Agent<br/>(10 Neo4j functions)"]
+        analyst["Analyst Agent<br/>(no tools — synthesis)"]
+    end
+    coord -->|as_tool| db
+    coord -->|as_tool| analyst
+    db -->|neo4j Bolt driver| neo4j[("Neo4j Aura<br/>(companies demo graph)")]
+```
+
+| Agent | Tools | Job |
+| --- | --- | --- |
+| **Coordinator Agent** | `database_agent.as_tool()`, `analyst_agent.as_tool()` | Orchestrates: delegates one focused question per facet to the Database Agent, concatenates responses, passes to the Analyst Agent. Never queries the graph or writes the report itself. |
+| **Database Agent** | 10 typed Neo4j functions | Calls the right tool for the request, returns one ```json``` block per call (raw rows verbatim — every `company_id`, `article_id`, title, date, sentiment, relationship type). No prose. |
+| **Analyst Agent** | none | Reads the JSON blocks, produces a structured report: Executive Summary, Profile, Recent Developments, Network table, Risks & Outlook. Cites IDs verbatim from the rows. |
+
+Composition is two `Agent.as_tool()` calls handed to the Coordinator's `tools=` — that's the whole multi-agent surface. The script is intentionally self-contained; [`../foundry-hosted/main.py`](../foundry-hosted/main.py) is a parallel near-identical file packaged for the Foundry hosted-agent runtime.
+
+## Function tools (Neo4j)
+
+Ten read-only functions over the public `companies` demo graph, organised the way the agent picks them — same set as [`microsoft-foundry/examples/foundry-sdk/`](../../../microsoft-foundry/examples/foundry-sdk/):
+
+**Discovery** — `search_companies`, `list_industries`, `companies_in_industry`
+**Profile** — `query_company`
+**Network** — `analyze_relationships`, `people_at_company`
+**News** — `search_news(company_name, query)` (vector — embeds `query` via [`OpenAIEmbeddingClient`](https://learn.microsoft.com/agent-framework/agents/providers/openai) against the Foundry `text-embedding-3-small` deployment, hits the demo graph's 1536-dim `news` index), `articles_in_month`, `get_article`, `companies_in_article`
+
+Plain Python functions with type hints and docstrings. Agent Framework auto-converts them to function tools — no decorator, no schema boilerplate.
+
+## Anti-hallucination contract
+
+`as_tool()` only forwards the inner agent's text to the parent — easy for an inner agent to silently summarise IDs away. Three guarantees in the instructions:
+
+1. **Database Agent** emits one fenced ```json``` block per tool call (`tool`, `args`, `rows`). No prose, no summaries.
+2. **Coordinator** passes those JSON blocks verbatim into the Analyst's `task`. Never strips down to bare IDs.
+3. **Analyst Agent** must cite every `company_id`, `article_id`, title, and relationship type from the rows. Real IDs look like `EIsFKrN_ZNLSWsvxdQfWutQ` / `ART11195006745` — short placeholders ("101", "AWS partnership") are flagged in the prompt as hallucination.
+
+Result: every value in the report appears verbatim in a tool result.
+
+## How it authenticates
+
+- **You → Foundry:** [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential) pinned to `AZURE_TENANT_ID` from `.env` so it works when `az login` is logged into multiple tenants.
+- **You → Neo4j:** the `neo4j` Python driver with username/password from `.env`. Defaults to `companies` / `companies` against the public demo graph.
+
+No Foundry tokens or Neo4j credentials are passed through the model — it sees only the tool schemas and the rows you return.
+
+## Override knobs
+
+Set these in `microsoft-foundry/.env`:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `FOUNDRY_QUESTION` | "Research Microsoft's position…" | The single user question. Pick something that exercises both database and analyst. |
+| `FOUNDRY_MODEL_DEPLOYMENT_NAME` | `gpt-4o-mini` | Model to run all three agents on. |
+| `NEO4J_URI` / `NEO4J_DATABASE` / `NEO4J_USERNAME` / `NEO4J_PASSWORD` | demo graph | Point at your own Aura or self-managed Neo4j. |

--- a/microsoft-agent-framework/examples/multi-agent/multi_agent_neo4j.py
+++ b/microsoft-agent-framework/examples/multi-agent/multi_agent_neo4j.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env -S uv run --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     # The meta-package "agent-framework" ships an empty __init__.py that
+#     # shadows -core's exports — so we depend on the split packages directly.
+#     "agent-framework-core>=1.2.1",
+#     "agent-framework-foundry>=1.2.1",
+#     "agent-framework-openai>=1.2.1",  # OpenAIEmbeddingClient (Entra-ID)
+#     "aiohttp",  # azure-ai-projects async transport
+#     "azure-identity",
+#     "python-dotenv",
+#     "neo4j>=5",
+# ]
+# ///
+"""Microsoft Agent Framework + Neo4j: multi-agent investment research, run locally.
+
+Implements the multi-agent spec from EXAMPLE_AGENT.md — Coordinator delegates
+to a Database Agent (10 typed Neo4j function tools) and an Analyst Agent
+(synthesis only). Self-contained on purpose; foundry-hosted/main.py is a
+parallel, near-identical file packaged for the Foundry hosted-agent runtime.
+"""
+
+import asyncio
+import os
+import sys
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from agent_framework import Agent, AgentContext, FunctionInvocationContext
+from agent_framework.foundry import FoundryChatClient
+from agent_framework.openai import OpenAIEmbeddingClient
+from azure.identity import AzureCliCredential
+from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
+from dotenv import load_dotenv
+from neo4j import GraphDatabase
+
+load_dotenv(Path(__file__).resolve().parents[3] / "microsoft-foundry" / ".env", override=True)
+
+DB = os.environ.get("NEO4J_DATABASE", "companies")
+driver = None  # initialised in main(); tools reference it via module lookup
+embeddings = None  # OpenAIEmbeddingClient — initialised in main()
+
+
+# Discovery ---------------------------------------------------------------
+
+def search_companies(search: str) -> list[dict]:
+    """Full-text fuzzy search for companies by name. Up to 20 ranked matches with company_id."""
+    rows, _, _ = driver.execute_query("""
+        CALL db.index.fulltext.queryNodes('entity', $search, {limit: 20})
+        YIELD node AS c, score
+        WHERE c:Organization
+        RETURN c.id AS company_id, c.name AS name, c.summary AS summary
+        ORDER BY score DESC
+    """, search=search, database_=DB)
+    return [r.data() for r in rows]
+
+
+def list_industries() -> list[dict]:
+    """All IndustryCategory names, alphabetical."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (i:IndustryCategory)
+        RETURN i.name AS industry
+        ORDER BY i.name
+    """, database_=DB)
+    return [r.data() for r in rows]
+
+
+def companies_in_industry(industry: str) -> list[dict]:
+    """Up to ten companies in the given IndustryCategory, with company_id."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (:IndustryCategory {name: $industry})<-[:HAS_CATEGORY]-(c:Organization)
+        RETURN c.id AS company_id, c.name AS name, c.summary AS summary
+        LIMIT 10
+    """, industry=industry, database_=DB)
+    return [r.data() for r in rows]
+
+
+# Profile -----------------------------------------------------------------
+
+def query_company(company_name: str) -> dict:
+    """Primary company lookup — returns company_id, name, industries, locations, leadership."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (o:Organization {name: $name})
+        OPTIONAL MATCH (o)-[:HAS_CATEGORY]->(c:IndustryCategory)
+        OPTIONAL MATCH (o)-[:IN_CITY]->(city:City)
+        OPTIONAL MATCH (o)-[:IN_COUNTRY]->(country:Country)
+        OPTIONAL MATCH (o)-[:HAS_CEO]->(ceo:Person)
+        OPTIONAL MATCH (o)-[:HAS_BOARD_MEMBER]->(b:Person)
+        RETURN o.id AS company_id, o.name AS name,
+               collect(DISTINCT c.name)[..5] AS industries,
+               collect(DISTINCT city.name)[..3] + collect(DISTINCT country.name) AS locations,
+               [x IN collect(DISTINCT {name: ceo.name, title: 'CEO'})
+                   + collect(DISTINCT {name: b.name, title: 'Board Member'})
+                 WHERE x.name IS NOT NULL][..6] AS leadership
+    """, name=company_name, database_=DB)
+    return rows[0].data() if rows else {}
+
+
+# Network -----------------------------------------------------------------
+
+def analyze_relationships(company_name: str) -> list[dict]:
+    """1-2 hop org-to-org connections (subsidiaries, suppliers, competitors, board, investors).
+    Returns connected orgs with relationship types and distance."""
+    rows, _, _ = driver.execute_query("""
+        MATCH path = (o1:Organization {name: $name})-[*1..2]-(o2:Organization)
+        WHERE o1 <> o2
+        RETURN DISTINCT o2.id AS company_id, o2.name AS organization,
+               [r IN relationships(path) | type(r)] AS relationships,
+               length(path) AS distance
+        ORDER BY distance LIMIT 20
+    """, name=company_name, database_=DB)
+    return [r.data() for r in rows]
+
+
+def people_at_company(company_id: str) -> list[dict]:
+    """People associated with a company (by company_id) and their roles (CEO, Board Member, …)."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (c:Organization {id: $id})-[role]-(p:Person)
+        RETURN replace(type(role), 'HAS_', '') AS role,
+               p.name AS person_name,
+               c.id AS company_id, c.name AS company_name
+    """, id=company_id, database_=DB)
+    return [r.data() for r in rows]
+
+
+# News --------------------------------------------------------------------
+
+async def search_news(company_name: str, query: str) -> list[dict]:
+    """Vector-search news about a company. Embeds `query` via the Foundry embedding
+    deployment (text-embedding-3-small, 1536d), then runs cosine similarity over
+    Chunks restricted to articles that MENTION the company. Returns up to 5 hits
+    with article_id, title, date, sentiment, the matched chunk text, and the score."""
+    result = await embeddings.get_embeddings([query])
+    vector = result[0].vector
+    # The 'news' vector index would return top-K across ALL chunks before our
+    # company filter — most of which won't mention this company. Compute cosine
+    # similarity directly over the pre-filtered company-mentioning chunks
+    # instead. Cheap at this scale (a few thousand chunks per major company).
+    # Off-thread the sync neo4j call so we don't block the event loop while
+    # the agent has other tool calls in flight.
+    def _query() -> list[dict]:
+        rows, _, _ = driver.execute_query("""
+            MATCH (a:Article)-[:MENTIONS]->(:Organization {name: $name})
+            MATCH (a)-[:HAS_CHUNK]->(c:Chunk)
+            WHERE c.embedding IS NOT NULL
+            WITH a, c, vector.similarity.cosine(c.embedding, $embedding) AS score
+            RETURN a.id AS article_id, a.title AS title, toString(a.date) AS date,
+                   a.sentiment AS sentiment, c.text AS text, score
+            ORDER BY score DESC LIMIT 5
+        """, name=company_name, embedding=vector, database_=DB)
+        return [r.data() for r in rows]
+    return await asyncio.to_thread(_query)
+
+
+def articles_in_month(date: str) -> list[dict]:
+    """Articles in the month starting at the given yyyy-mm-dd date."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (a:Article)
+        WHERE date($date) <= date(a.date) < date($date) + duration('P1M')
+        RETURN a.id AS article_id, a.author AS author, a.title AS title,
+               toString(a.date) AS date, a.sentiment AS sentiment
+        ORDER BY a.date DESC LIMIT 25
+    """, date=date, database_=DB)
+    return [r.data() for r in rows]
+
+
+def get_article(article_id: str) -> dict:
+    """Full article body, summary, sentiment, joined from chunks."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (a:Article {id: $id})-[:HAS_CHUNK]->(c:Chunk)
+        WITH a, c ORDER BY id(c) ASC
+        WITH a, collect(c.text) AS contents
+        RETURN a.id AS article_id, a.author AS author, a.title AS title,
+               toString(a.date) AS date, a.summary AS summary,
+               a.siteName AS site, a.sentiment AS sentiment,
+               apoc.text.join(contents, ' ') AS content
+    """, id=article_id, database_=DB)
+    return rows[0].data() if rows else {}
+
+
+def companies_in_article(article_id: str) -> list[dict]:
+    """Companies mentioned in a specific article (by article_id)."""
+    rows, _, _ = driver.execute_query("""
+        MATCH (a:Article {id: $id})-[:MENTIONS]->(c:Organization)
+        RETURN c.id AS company_id, c.name AS name, c.summary AS summary
+    """, id=article_id, database_=DB)
+    return [r.data() for r in rows]
+
+
+DATABASE_TOOLS = [
+    search_companies, list_industries, companies_in_industry,
+    query_company,
+    analyze_relationships, people_at_company,
+    search_news, articles_in_month, get_article, companies_in_article,
+]
+
+
+# Middleware --------------------------------------------------------------
+
+async def log_agent(context: AgentContext, call_next: Callable[[], Awaitable[None]]) -> None:
+    """Log which agent is invoked, with a short preview of the input."""
+    name = context.agent.name or "?"
+    last = context.messages[-1].text if context.messages else ""
+    preview = (last[:80] + "…") if len(last) > 80 else last
+    print(f"  [agent={name}] {preview}")
+    await call_next()
+
+
+async def log_tool(context: FunctionInvocationContext, call_next: Callable[[], Awaitable[None]]) -> None:
+    """Log every tool invocation (name + args)."""
+    args = ", ".join(f"{k}={v!r}" for k, v in (context.arguments or {}).items())
+    print(f"    → {context.function.name}({args})")
+    await call_next()
+
+
+# Agent instructions ------------------------------------------------------
+
+DATABASE_INSTRUCTIONS = """\
+You are a data-access agent over a Neo4j knowledge graph of companies (Organization),
+people (Person), industries (IndustryCategory), locations (City, Country), and
+articles (Article). Other agents call you to fetch facts.
+
+Tools (read-only):
+  Discovery: search_companies, list_industries, companies_in_industry
+  Profile:   query_company
+  Network:   analyze_relationships, people_at_company
+  News:      search_news (vector — needs a query string), articles_in_month, get_article, companies_in_article
+
+Output protocol — STRICT, machine-readable
+  Your reply is consumed by another agent, not a human. Output ONE fenced
+  ```json``` block per tool call you made, with this exact shape:
+
+    ```json
+    {
+      "tool": "<tool name>",
+      "args": { ... what you passed in ... },
+      "rows": [ ... the tool result, verbatim, every field ... ]
+    }
+    ```
+
+  Rules
+  • Include EVERY field the tool returned — `company_id`, `article_id`, `title`,
+    `date`, `sentiment`, `relationships`, `distance`, `industries`, `locations`,
+    `leadership`, etc. Real IDs look like `EIsFKrN_ZNLSWsvxdQfWutQ` and
+    `ART11195006745`; never shorten or substitute.
+  • If a tool returns no rows, set `"rows": []`.
+  • No prose. No summary. No headings. Only the JSON blocks, one per call.
+  • Never reason from prior knowledge — the only valid content is what the
+    tools returned this turn.
+"""
+
+ANALYST_INSTRUCTIONS = """\
+You are an investment-research analyst. Your input is one or more ```json```
+blocks the database agent gathered. Each block has `tool`, `args`, and `rows`.
+Synthesize a concise investment-research report from those rows — and only
+those rows.
+
+Report structure
+  Executive Summary   — 2-3 sentences with the headline finding.
+  Company Profile     — industries, locations, leadership; one short paragraph.
+                        Cite the `company_id` once.
+  Recent Developments — bullet list. Each bullet MUST start with the real
+                        `article_id` from the rows, then the `title`, `date`,
+                        and `sentiment`.
+  Network             — Markdown table with columns: `company_id`,
+                        `organization`, `relationships`, `distance` — copied
+                        from the rows verbatim.
+  Risks & Outlook     — what the data suggests, and what's missing.
+
+Rules — STRICT, no exceptions
+  • Every `company_id`, `article_id`, `title`, and relationship type in your
+    report must appear verbatim in the input rows. Real IDs look like
+    `EIsFKrN_ZNLSWsvxdQfWutQ` and `ART11195006745`.
+  • If you find yourself writing a short numeric ID like "101" or "201", or a
+    generic name ("Strategic Partner", "AWS partnership") that isn't in the
+    rows, STOP — that is hallucination. Re-read the JSON blocks.
+  • If a section has no supporting rows, write "(no data)" — never pad.
+  • Insight is welcome in Risks & Outlook only, and only insight that follows
+    directly from the rows.
+"""
+
+COORDINATOR_INSTRUCTIONS = """\
+You orchestrate investment research. You delegate to two specialists:
+
+  database_agent — fetches rows from the graph. Returns one or more
+                   ```json``` blocks per call, each with `tool`, `args`,
+                   and `rows`.
+  analyst        — turns those JSON blocks into an investment-research report.
+
+Workflow
+  1. Call `database_agent` once per facet: company profile, peers, recent
+     news, relationships, key people. Each call should be a focused request
+     like "query_company('Microsoft')" or
+     "companies_in_industry('Software Companies')".
+  2. CONCATENATE every `database_agent` response verbatim into one string
+     and pass that string as the `task` to `analyst`. The analyst MUST see
+     the raw JSON blocks — never strip them down to bare IDs or summaries.
+  3. Return the analyst's report verbatim — don't paraphrase or re-summarize.
+
+Never query the graph yourself. Never write the report yourself. Faithful
+relaying is your job.
+"""
+
+
+# Entry -------------------------------------------------------------------
+
+async def main() -> None:
+    project_endpoint = os.environ.get("FOUNDRY_PROJECT_ENDPOINT")
+    tenant_id = os.environ.get("AZURE_TENANT_ID")
+    neo4j_uri = os.environ.get("NEO4J_URI")
+    embedding_deployment = os.environ.get("FOUNDRY_EMBEDDING_DEPLOYMENT_NAME", "text-embedding-3-small")
+    if not (project_endpoint and tenant_id and neo4j_uri):
+        sys.exit(
+            "Missing FOUNDRY_PROJECT_ENDPOINT, AZURE_TENANT_ID, or NEO4J_URI. "
+            "Run microsoft-foundry/infra/deploy.sh first."
+        )
+
+    # Foundry account base URL: strip the /api/projects/<project> path off the project endpoint.
+    # OpenAIEmbeddingClient routes /openai/deployments/<model>/embeddings under it.
+    account_endpoint = project_endpoint.split("/api/")[0]
+
+    global driver, embeddings
+    driver = GraphDatabase.driver(
+        neo4j_uri,
+        auth=(os.environ.get("NEO4J_USERNAME", "companies"),
+              os.environ.get("NEO4J_PASSWORD", "companies")),
+    )
+    embed_credential = AsyncAzureCliCredential(tenant_id=tenant_id)
+    try:
+        # OpenAIEmbeddingClient is the canonical agent-framework path for Entra-ID
+        # auth against an Azure OpenAI / Foundry endpoint (FoundryEmbeddingClient
+        # is API-key only and won't work with disableLocalAuth=true accounts).
+        # See microsoft/agent-framework: python/samples/02-agents/embeddings/openai_embeddings_on_azure.py
+        embeddings = OpenAIEmbeddingClient(
+            model=embedding_deployment,
+            azure_endpoint=account_endpoint,
+            credential=embed_credential,
+        )
+
+        client = FoundryChatClient(
+            project_endpoint=project_endpoint,
+            model=os.environ.get("FOUNDRY_MODEL_DEPLOYMENT_NAME", "gpt-4o-mini"),
+            credential=AzureCliCredential(tenant_id=tenant_id),
+        )
+
+        # Names match EXAMPLE_AGENT.md — `database_agent`, `analyst`,
+        # `coordinator` — so the trace and instructions read consistently
+        # across the spec, the code, and the model's tool-call surface.
+        database_agent = Agent(
+            client=client,
+            middleware=[log_agent, log_tool],
+            name="database_agent",
+            instructions=DATABASE_INSTRUCTIONS,
+            tools=DATABASE_TOOLS,
+        )
+        analyst_agent = Agent(
+            client=client,
+            middleware=[log_agent, log_tool],
+            name="analyst",
+            instructions=ANALYST_INSTRUCTIONS,
+        )
+        coordinator = Agent(
+            client=client,
+            middleware=[log_agent, log_tool],
+            name="coordinator",
+            instructions=COORDINATOR_INSTRUCTIONS,
+            tools=[
+                database_agent.as_tool(
+                    name="database_agent",
+                    description="Fetch company / news / relationship / people rows from the Neo4j graph. Always returns IDs for follow-up calls.",
+                    arg_name="task",
+                    arg_description="What to fetch — be specific (which company, what aspect).",
+                ),
+                analyst_agent.as_tool(
+                    name="analyst",
+                    description="Synthesize gathered rows into an investment-research report.",
+                    arg_name="task",
+                    arg_description="Pass the rows the database agent returned, plus the analysis goal.",
+                ),
+            ],
+        )
+
+        question = os.environ.get(
+            "FOUNDRY_QUESTION",
+            "Research Microsoft's position in the software industry. Gather company "
+            "profile, recent news, and key relationships, then synthesize an "
+            "investment outlook.",
+        )
+        print(f"> {question}\n")
+        result = await coordinator.run(question)
+        print(result)
+    finally:
+        await embed_credential.close()
+        driver.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/microsoft-foundry/.env.example
+++ b/microsoft-foundry/.env.example
@@ -44,6 +44,7 @@ FOUNDRY_ACCOUNT_NAME=<your-foundry-ai-services-account>
 FOUNDRY_PROJECT_NAME=<your-foundry-project>
 FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
 FOUNDRY_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+FOUNDRY_EMBEDDING_DEPLOYMENT_NAME=text-embedding-3-small
 
 # Set this after you add the Neo4j MCP server as a custom MCP tool in the
 # Foundry portal — use whatever name you gave that connection.

--- a/microsoft-foundry/infra/README.md
+++ b/microsoft-foundry/infra/README.md
@@ -47,13 +47,22 @@ The Python example uses `AzureCliCredential` from your `az login`
 session. See [`microsoft-foundry/.env.example`](../.env.example)
 for the full schema.
 
-`azd up` prompts for three things on first run:
+`azd up` prompts on first run unless these are already set in the
+azd env. `deploy.sh` defaults `AZURE_LOCATION` to `swedencentral` so
+the same Foundry project can later host the agent-framework
+[`foundry-hosted`](../../microsoft-agent-framework/examples/foundry-hosted/)
+example without having to redeploy in a different region.
 
-| Prompt | Meaning | Examples |
-| --- | --- | --- |
-| **Environment name** | Resource suffix. | `dev`, `prod` |
-| **Subscription** | Azure subscription to deploy into. | — |
-| **Location** | Azure region. | `eastus2`, `westeurope` |
+| Prompt | Meaning | Default | Examples |
+| --- | --- | --- | --- |
+| **Environment name** | Resource suffix. | — | `dev`, `prod` |
+| **Subscription** | Azure subscription to deploy into. | — | — |
+| **Location** | Azure region. | `swedencentral` | `northcentralus`, `eastus2` |
+
+If you don't need hosted agents and want a different region, override
+with `azd env set AZURE_LOCATION <region>` before `./deploy.sh`. For
+hosted-agent compatibility, stick to Sweden Central, North Central US,
+Canada Central, or Australia East ([current list](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents)).
 
 The Bicep is subscription-scoped, so `azd` creates
 `rg-foundry-neo4j-<env>` for you.
@@ -186,10 +195,11 @@ role assignment.
 
 **`azd up` fails with `DeploymentModelNotSupported` or a quota error.**
 The default model `gpt-4o-mini` (version `2024-07-18`) is broadly
-available, but not in every region. Foundry agent APIs are
-supported in `eastus`, `eastus2`, `swedencentral`, `westus`,
-and `westus3`. To switch models, set overrides before running
-`./deploy.sh`:
+available, but not in every region. Foundry agent APIs are supported
+in `eastus`, `eastus2`, `swedencentral`, `westus`, `westus3`, and
+others; Foundry hosted agents narrow that to Sweden Central, North
+Central US, Canada Central, and Australia East. To switch models,
+set overrides before running `./deploy.sh`:
 
 ```bash
 azd env set FOUNDRY_MODEL_NAME gpt-5-mini

--- a/microsoft-foundry/infra/azure.yaml
+++ b/microsoft-foundry/infra/azure.yaml
@@ -7,7 +7,7 @@ infra:
 hooks:
   preprovision:
     posix:
-      shell: bash
-      run: hooks/preprovision.sh
+      shell: sh
+      run: bash hooks/preprovision.sh
       interactive: true
       continueOnError: false

--- a/microsoft-foundry/infra/deploy.sh
+++ b/microsoft-foundry/infra/deploy.sh
@@ -22,6 +22,7 @@ foundry_account_name=""
 foundry_project_name=""
 foundry_project_endpoint=""
 foundry_model_deployment_name="gpt-4o-mini"
+foundry_embedding_deployment_name="text-embedding-3-small"
 neo4j_mcp_connection_name=""
 
 read_kv_file() {
@@ -34,17 +35,21 @@ read_kv_file() {
       continue
     fi
 
+    # Note: each `[ -n "$value" ] && var=...` returns 1 when value is empty,
+    # which under `set -e` would silently kill the script. Each branch ends in
+    # `|| :` so a missing/empty value is a no-op, not a script abort.
     case "$key" in
-      NEO4J_URI)                     [ -n "$value" ] && neo4j_uri="$value" ;;
-      NEO4J_DATABASE)                [ -n "$value" ] && neo4j_database="$value" ;;
-      NEO4J_USERNAME)                [ -n "$value" ] && neo4j_username="$value" ;;
-      NEO4J_PASSWORD)                [ -n "$value" ] && neo4j_password="$value" ;;
-      FOUNDRY_RESOURCE_GROUP)        [ -n "$value" ] && foundry_resource_group="$value" ;;
-      FOUNDRY_ACCOUNT_NAME)          [ -n "$value" ] && foundry_account_name="$value" ;;
-      FOUNDRY_PROJECT_NAME)          [ -n "$value" ] && foundry_project_name="$value" ;;
-      FOUNDRY_PROJECT_ENDPOINT)      [ -n "$value" ] && foundry_project_endpoint="$value" ;;
-      FOUNDRY_MODEL_DEPLOYMENT_NAME) [ -n "$value" ] && foundry_model_deployment_name="$value" ;;
-      NEO4J_MCP_CONNECTION_NAME)     [ -n "$value" ] && neo4j_mcp_connection_name="$value" ;;
+      NEO4J_URI)                     [ -n "$value" ] && neo4j_uri="$value"                          || : ;;
+      NEO4J_DATABASE)                [ -n "$value" ] && neo4j_database="$value"                     || : ;;
+      NEO4J_USERNAME)                [ -n "$value" ] && neo4j_username="$value"                     || : ;;
+      NEO4J_PASSWORD)                [ -n "$value" ] && neo4j_password="$value"                     || : ;;
+      FOUNDRY_RESOURCE_GROUP)        [ -n "$value" ] && foundry_resource_group="$value"             || : ;;
+      FOUNDRY_ACCOUNT_NAME)          [ -n "$value" ] && foundry_account_name="$value"               || : ;;
+      FOUNDRY_PROJECT_NAME)          [ -n "$value" ] && foundry_project_name="$value"               || : ;;
+      FOUNDRY_PROJECT_ENDPOINT)      [ -n "$value" ] && foundry_project_endpoint="$value"           || : ;;
+      FOUNDRY_MODEL_DEPLOYMENT_NAME)     [ -n "$value" ] && foundry_model_deployment_name="$value"      || : ;;
+      FOUNDRY_EMBEDDING_DEPLOYMENT_NAME) [ -n "$value" ] && foundry_embedding_deployment_name="$value" || : ;;
+      NEO4J_MCP_CONNECTION_NAME)         [ -n "$value" ] && neo4j_mcp_connection_name="$value"          || : ;;
     esac
   done < "$file"
 }
@@ -75,9 +80,37 @@ azd_get() {
   fi
 }
 
+# Default AZURE_LOCATION to swedencentral if not already set. Sweden Central is
+# the only region in our supported list that ALSO supports Foundry hosted
+# agents (Australia East / Canada Central / North Central US / Sweden Central),
+# so deploying here means the same Foundry project can later host the
+# agent-framework foundry-hosted example. Override with `azd env set
+# AZURE_LOCATION ...` before re-running deploy.sh, or pick interactively the
+# first time `azd up` prompts.
+if [ -z "$(azd_get AZURE_LOCATION)" ]; then
+  azd env set AZURE_LOCATION swedencentral >/dev/null
+fi
+
+# The `azure.ai.agents` azd extension's postdeploy hook reads AZURE_TENANT_ID
+# from the azd env. azd doesn't auto-stamp it, so derive it from `az account
+# show` (or an existing infra .env) and seed it before `azd up`.
+seed_tenant_id="$(azd_get AZURE_TENANT_ID)"
+if [ -z "$seed_tenant_id" ] && command -v az >/dev/null; then
+  seed_sub="$(azd_get AZURE_SUBSCRIPTION_ID)"
+  [ -z "$seed_sub" ] && seed_sub="$(az account show --query id -o tsv 2>/dev/null || true)"
+  if [ -n "$seed_sub" ]; then
+    seed_tenant_id="$(az account show --subscription "$seed_sub" --query tenantId -o tsv 2>/dev/null || true)"
+    [ -n "$seed_tenant_id" ] && azd env set AZURE_TENANT_ID "$seed_tenant_id" >/dev/null
+  fi
+fi
+
 # The Foundry opt-in prompt runs as an azd preprovision hook
 # (hooks/preprovision.sh) so it happens after azd has created the env.
-azd up "$@"
+# Don't `set -e` exit on a non-zero `azd up` — even when post-deploy hooks fail
+# (e.g. the azure.ai.agents extension), the Bicep outputs are still in the
+# azd env and we can still stamp the shared .env. Capture status to report.
+azd_up_status=0
+azd up "$@" || azd_up_status=$?
 
 # Read deployed values back from the azd env. Empty when Foundry was disabled.
 endpoint="$(azd_get mcpEndpoint)"
@@ -86,6 +119,7 @@ foundry_account_out="$(azd_get foundryAccountName)"
 foundry_project_out="$(azd_get foundryProjectName)"
 foundry_project_endpoint_out="$(azd_get foundryProjectEndpoint)"
 foundry_model_out="$(azd_get foundryModelDeploymentName)"
+foundry_embedding_out="$(azd_get foundryEmbeddingDeploymentName)"
 azure_subscription_id="$(azd_get AZURE_SUBSCRIPTION_ID)"
 azure_tenant_id="$(azd_get AZURE_TENANT_ID)"
 if command -v az >/dev/null; then
@@ -100,6 +134,7 @@ fi
 [ -n "$foundry_project_out" ]          && foundry_project_name="$foundry_project_out"
 [ -n "$foundry_project_endpoint_out" ] && foundry_project_endpoint="$foundry_project_endpoint_out"
 [ -n "$foundry_model_out" ]            && foundry_model_deployment_name="$foundry_model_out"
+[ -n "$foundry_embedding_out" ]        && foundry_embedding_deployment_name="$foundry_embedding_out"
 
 # Write microsoft-foundry/.env so every example script in this section can
 # source the same file.
@@ -130,13 +165,15 @@ FOUNDRY_ACCOUNT_NAME=${foundry_account_name}
 FOUNDRY_PROJECT_NAME=${foundry_project_name}
 FOUNDRY_PROJECT_ENDPOINT=${foundry_project_endpoint}
 FOUNDRY_MODEL_DEPLOYMENT_NAME=${foundry_model_deployment_name}
+FOUNDRY_EMBEDDING_DEPLOYMENT_NAME=${foundry_embedding_deployment_name}
 
 # Neo4j MCP project connection name. Set this manually after creating the
 # connection in the Foundry portal — see microsoft-foundry/examples/mcp/README.md.
 NEO4J_MCP_CONNECTION_NAME=${neo4j_mcp_connection_name}
 EOF
 
-cat <<EOF
+if [ "$azd_up_status" -eq 0 ]; then
+  cat <<EOF
 
 Neo4j MCP server is ready.
 
@@ -150,3 +187,16 @@ Smoke test:
   ./test-mcp.sh "${endpoint}"
 
 EOF
+else
+  cat <<EOF
+
+azd up exited with status ${azd_up_status} — check the log above. The shared
+.env was still refreshed from whatever values made it into the azd env, so
+re-running may pick up where it left off.
+
+Shared environment file:
+  ${shared_env}
+
+EOF
+  exit "$azd_up_status"
+fi

--- a/microsoft-foundry/infra/infra/foundry.bicep
+++ b/microsoft-foundry/infra/infra/foundry.bicep
@@ -21,6 +21,18 @@ param modelSkuName string
 @description('Foundry model deployment capacity, in thousands of tokens per minute.')
 param modelCapacity int
 
+@description('Foundry embedding model name (e.g. text-embedding-3-small).')
+param embeddingModelName string
+
+@description('Foundry embedding model version.')
+param embeddingModelVersion string
+
+@description('Foundry embedding model deployment SKU.')
+param embeddingModelSkuName string
+
+@description('Foundry embedding model deployment capacity, in thousands of tokens per minute.')
+param embeddingModelCapacity int
+
 @description('Principal ID (Entra object ID) granted Azure AI Developer on the Foundry account so the signed-in user can call the Foundry data plane after az login. Empty disables the role assignment.')
 param principalId string
 
@@ -44,7 +56,7 @@ var projectName = 'proj-${baseName}'
 // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/ai-machine-learning
 var azureAiDeveloperRoleId = '64702f94-c441-49e6-a78b-ef80e0188fee'
 
-resource foundryAccount 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
+resource foundryAccount 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   name: accountName
   location: location
   tags: commonTags
@@ -58,8 +70,18 @@ resource foundryAccount 'Microsoft.CognitiveServices/accounts@2025-04-01-preview
   properties: {
     allowProjectManagement: true
     customSubDomainName: accountName
+    networkAcls: {
+      defaultAction: 'Allow'
+      virtualNetworkRules: []
+      ipRules: []
+    }
     publicNetworkAccess: 'Enabled'
-    disableLocalAuth: false
+    // disableLocalAuth: true matches the Azure-Samples/azd-ai-starter-basic
+    // template; the agent identity that hosted agents use is Entra-ID-based
+    // anyway and our examples authenticate via `az login` /
+    // DefaultAzureCredential, so disabling key auth is safe and avoids a
+    // class of accidental key leakage.
+    disableLocalAuth: true
   }
 }
 
@@ -79,6 +101,30 @@ resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-
   }
 }
 
+// Embedding-model deployment — used by the agent-framework multi-agent example
+// to vector-search news. The default text-embedding-3-small produces 1536-dim
+// embeddings, matching the public `companies` demo graph's `news` vector index.
+// Serial dependency on modelDeployment because ARM doesn't allow two
+// deployments under the same account to provision in parallel.
+resource embeddingDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: foundryAccount
+  name: embeddingModelName
+  sku: {
+    name: embeddingModelSkuName
+    capacity: embeddingModelCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: embeddingModelName
+      version: embeddingModelVersion
+    }
+  }
+  dependsOn: [
+    modelDeployment
+  ]
+}
+
 resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-preview' = {
   parent: foundryAccount
   name: projectName
@@ -93,8 +139,17 @@ resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-04-0
   }
   dependsOn: [
     modelDeployment
+    embeddingDeployment
   ]
 }
+
+// No `capabilityHosts` resource is needed for the hosted-agents flow this
+// project participates in. The starter template
+// (Azure-Samples/azd-ai-starter-basic) defaults ENABLE_HOSTED_AGENTS=false
+// and still deploys agents successfully via `azd ai agent init` — public-
+// endpoint hosted agents work against any project that has
+// `allowProjectManagement: true` (set above on the account). The
+// capabilityHost is only needed for BYO-VNet / custom-subnet scenarios.
 
 resource deployerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(principalId)) {
   scope: foundryAccount
@@ -110,3 +165,4 @@ output accountName string = foundryAccount.name
 output projectName string = foundryProject.name
 output projectEndpoint string = foundryProject.properties.endpoints['AI Foundry API']
 output modelDeploymentName string = modelDeployment.name
+output embeddingDeploymentName string = embeddingDeployment.name

--- a/microsoft-foundry/infra/infra/main.bicep
+++ b/microsoft-foundry/infra/infra/main.bicep
@@ -87,6 +87,18 @@ param foundryModelSkuName string = 'GlobalStandard'
 @description('Foundry model deployment capacity (thousands of tokens per minute).')
 param foundryModelCapacity string = '30'
 
+@description('Foundry embedding model deployment name. Must match a model available in the chosen region. Used by the agent-framework multi-agent example to do vector search over the public companies demo graph (which uses 1536-dim cosine embeddings).')
+param foundryEmbeddingModelName string = 'text-embedding-3-small'
+
+@description('Foundry embedding model version.')
+param foundryEmbeddingModelVersion string = '1'
+
+@description('Foundry embedding model SKU.')
+param foundryEmbeddingModelSkuName string = 'GlobalStandard'
+
+@description('Foundry embedding model capacity (thousands of tokens per minute).')
+param foundryEmbeddingModelCapacity string = '30'
+
 @description('Entra object ID granted Azure AI Developer on the Foundry account so the signed-in user can call the Foundry data plane after az login. azd auto-populates this from the signed-in user. Empty disables the role assignment.')
 param principalId string = ''
 
@@ -151,6 +163,10 @@ module foundry './foundry.bicep' = if (foundryEnabled) {
     modelVersion: foundryModelVersion
     modelSkuName: foundryModelSkuName
     modelCapacity: int(foundryModelCapacity)
+    embeddingModelName: foundryEmbeddingModelName
+    embeddingModelVersion: foundryEmbeddingModelVersion
+    embeddingModelSkuName: foundryEmbeddingModelSkuName
+    embeddingModelCapacity: int(foundryEmbeddingModelCapacity)
     principalId: principalId
     principalType: principalType
   }
@@ -168,3 +184,12 @@ output foundryAccountName string = foundryEnabled ? foundry.outputs.accountName 
 output foundryProjectName string = foundryEnabled ? foundry.outputs.projectName : ''
 output foundryProjectEndpoint string = foundryEnabled ? foundry.outputs.projectEndpoint : ''
 output foundryModelDeploymentName string = foundryEnabled ? foundry.outputs.modelDeploymentName : ''
+output foundryEmbeddingDeploymentName string = foundryEnabled ? foundry.outputs.embeddingDeploymentName : ''
+
+// Names the `azure.ai.agents` azd extension expects in its postdeploy hook.
+// Without these, `azd up` fails with "AZURE_AI_PROJECT_ENDPOINT is not set"
+// once the extension is installed locally. `AZURE_TENANT_ID` is the third
+// var the hook requires; it isn't a deployment artifact, so deploy.sh
+// seeds it into the azd env from `az account show` before `azd up`.
+output AZURE_AI_PROJECT_ENDPOINT string = foundryEnabled ? foundry.outputs.projectEndpoint : ''
+output AZURE_AI_MODEL_DEPLOYMENT_NAME string = foundryEnabled ? foundry.outputs.modelDeploymentName : ''


### PR DESCRIPTION
Refactors `microsoft-agent-framework/` like #45 did for `microsoft-foundry/`. Two examples on the [EXAMPLE_AGENT.md](./EXAMPLE_AGENT.md) multi-agent spec, both running against the same Foundry project that `microsoft-foundry/` already deploys:

- [`examples/multi-agent/`](./microsoft-agent-framework/examples/multi-agent/) — uv-runnable single file. `FoundryChatClient` against the `microsoft-foundry/` deployment. Coordinator + Database + Analyst via `agent.as_tool()`. Same 10 Neo4j function tools as foundry-sdk.
- [`examples/foundry-hosted/`](./microsoft-agent-framework/examples/foundry-hosted/) — same graph packaged as a Foundry hosted agent (`agent-framework-foundry-hosting` / `ResponsesHostServer`). Standard flat layout matching the canonical agent-framework hosted samples. Deployed against the **same** `microsoft-foundry/` Foundry project via `azd ai agent init -p <project-id> -d gpt-4o-mini`.

Both verified end-to-end including the deployed hosted runtime. Strict JSON-block protocol between sub-agents so the agent-as-tools text bridge doesn't drop IDs — every `company_id` and `article_id` in the synthesized report appears verbatim in a tool result.

The two files are self-contained on purpose. Sharing the agent definition across folders fights the Foundry hosted-agent docker build context (`azd ai agent init -m <url>` only copies the manifest folder when scaffolding), so we keep one parallel copy in each example with a banner comment pointing at the other.

Vector `search_news(company_name, query)` per the EXAMPLE_AGENT.md spec uses [`OpenAIEmbeddingClient`](https://learn.microsoft.com/agent-framework/agents/providers/openai) — the canonical agent-framework Entra-ID path for Azure OpenAI / Foundry endpoints. (`FoundryEmbeddingClient` is API-key only and won't work with `disableLocalAuth: true` accounts.) The Cypher uses `vector.similarity.cosine(c.embedding, $embedding)` over MENTIONS-filtered chunks rather than `db.index.vector.queryNodes` directly, so the company filter doesn't get drowned by top-K results.

Separate commit for `microsoft-foundry/infra/` DX fixes discovered along the way:
- newer azd rejects `shell: bash` in `azure.yaml` hooks → `shell: sh` + `run: bash hooks/...`.
- the `azure.ai.agents` postdeploy hook needs `AZURE_TENANT_ID` / `AZURE_AI_PROJECT_ENDPOINT` / `AZURE_AI_MODEL_DEPLOYMENT_NAME` in the azd env — auto-stamp via Bicep outputs + `az account show`.
- pre-existing silent-exit bug in `read_kv_file`: empty-value `[ -n "$value" ] && var=...` returned 1, killing the script under `set -e`. Trailing `|| :` makes empty values a no-op.
- align `foundry.bicep` account properties with `Azure-Samples/azd-ai-starter-basic` (`disableLocalAuth: true`, explicit `networkAcls`, API version 2025-06-01) so the project accepts hosted-agent registrations via `-p`.
- default `AZURE_LOCATION` to `swedencentral` — the only region in our supported list that also supports Foundry hosted agents.
- add a `text-embedding-3-small` (1536d) deployment matching the public `companies` demo graph's `news` vector index for the multi-agent example's vector search.

Net effect: one `cd microsoft-foundry/infra && ./deploy.sh` provisions a Foundry project that hosts both the Neo4j MCP container app AND any agent-framework hosted agent deployed via `azd ai agent init -p ...`. One deployment, one `.env`, both use cases.

Gotchas worth knowing:
- the `agent-framework` PyPI meta-package ships an empty `__init__.py` that shadows `-core`'s exports — pin `agent-framework-core` + `agent-framework-foundry` + `agent-framework-openai` directly.
- `azd ai agent init -m` wants a file path, not a folder (Microsoft docs misleading).