### PR TITLE
Fix Cloud Shell hangs and silent prompts in microsoft-foundry deploy

### DIFF
--- a/microsoft-agent-framework/README.md
+++ b/microsoft-agent-framework/README.md
@@ -27,8 +27,11 @@ Both examples implement the same multi-agent graph. The local example runs your 
 ## Quick start
 
 ```bash
+git clone https://github.com/neo4j-labs/neo4j-agent-integrations.git
+cd neo4j-agent-integrations
+azd config set auth.useAzCliAuth true    # one-time: let azd reuse az's session
 az login
-cd microsoft-foundry/infra && ./deploy.sh    # one-time, opt in to Foundry
+cd microsoft-foundry/infra && ./deploy.sh    # one-time, provisions Foundry
 cd ../../microsoft-agent-framework/examples/multi-agent && uv run multi_agent_neo4j.py
 ```
 

--- a/microsoft-foundry/README.md
+++ b/microsoft-foundry/README.md
@@ -23,9 +23,12 @@ The MCP path is shared infrastructure: deploy once, attach from Foundry, Copilot
 ## Quick Start
 
 ```bash
+git clone https://github.com/neo4j-labs/neo4j-agent-integrations.git
+cd neo4j-agent-integrations
+azd config set auth.useAzCliAuth true    # one-time: let azd reuse az's session
 az login
 cd microsoft-foundry/infra
-./deploy.sh                    # answer "Y" at the Foundry provisioning prompt
+./deploy.sh
 ./test-mcp.sh "$(azd env get-value mcpEndpoint)"
 ```
 

--- a/microsoft-foundry/infra/deploy.sh
+++ b/microsoft-foundry/infra/deploy.sh
@@ -8,11 +8,13 @@ command -v azd >/dev/null || {
   exit 1
 }
 
-# Fail fast if azd isn't authenticated. azd keeps its own token cache separate
-# from `az`, so `az login` alone isn't enough — and without this check, `azd
-# up` can hang silently waiting for an interactive token refresh.
-if ! azd auth login --check-status >/dev/null 2>&1; then
-  echo "Not signed in to azd. Run: azd auth login" >&2
+# Fail fast if neither `az` nor `azd` is authenticated. Without this check,
+# `azd up` can hang silently waiting for an interactive token refresh.
+# Either tool being signed in is enough: with `azd config set
+# auth.useAzCliAuth true` (recommended in the Quick Start), azd reuses `az`'s
+# session; otherwise azd needs its own `azd auth login`.
+if ! az account show >/dev/null 2>&1 && ! azd auth login --check-status >/dev/null 2>&1; then
+  echo "Not signed in. Run: az login (and 'azd auth login' if azd uses standalone auth)" >&2
   exit 1
 fi
 
@@ -66,6 +68,15 @@ read_kv_file() {
 read_kv_file "$shared_env"
 read_kv_file ".env"
 
+# Default to an azd env called "demo" so `azd up` doesn't prompt on a fresh
+# shell (e.g. Azure Cloud Shell). Must run before any `azd env set` below.
+# The env name is an azd-local identifier and becomes the suffix on every
+# resource (rg-foundry-neo4j-demo, ...). Run `azd env new <name>` before
+# deploy.sh to use a different name.
+if [ ! -d .azure ] || [ -z "$(ls -A .azure 2>/dev/null)" ]; then
+  azd env new demo >/dev/null
+fi
+
 # Forward local infra .env values into the azd environment so deployment
 # parameters reach the Bicep. azd up itself prompts for AZURE_ENV_NAME, the
 # subscription, and AZURE_LOCATION.
@@ -87,14 +98,6 @@ azd_get() {
     printf '%s' "$out"
   fi
 }
-
-# Default to an azd env called "demo" so `azd up` doesn't prompt on a fresh
-# shell (e.g. Azure Cloud Shell). The env name is an azd-local identifier and
-# becomes the suffix on every resource (rg-foundry-neo4j-demo, ...). Run
-# `azd env new <name>` before deploy.sh to use a different name.
-if [ ! -d .azure ] || [ -z "$(ls -A .azure 2>/dev/null)" ]; then
-  azd env new demo >/dev/null
-fi
 
 # Default AZURE_LOCATION to swedencentral if not already set. Sweden Central is
 # the only region in our supported list that ALSO supports Foundry hosted

--- a/microsoft-foundry/infra/deploy.sh
+++ b/microsoft-foundry/infra/deploy.sh
@@ -8,6 +8,14 @@ command -v azd >/dev/null || {
   exit 1
 }
 
+# Fail fast if azd isn't authenticated. azd keeps its own token cache separate
+# from `az`, so `az login` alone isn't enough — and without this check, `azd
+# up` can hang silently waiting for an interactive token refresh.
+if ! azd auth login --check-status >/dev/null 2>&1; then
+  echo "Not signed in to azd. Run: azd auth login" >&2
+  exit 1
+fi
+
 shared_env="$(cd .. && pwd)/.env"
 
 # Demo defaults (match .env.sample). Overridden below by the existing shared
@@ -79,6 +87,14 @@ azd_get() {
     printf '%s' "$out"
   fi
 }
+
+# Default to an azd env called "demo" so `azd up` doesn't prompt on a fresh
+# shell (e.g. Azure Cloud Shell). The env name is an azd-local identifier and
+# becomes the suffix on every resource (rg-foundry-neo4j-demo, ...). Run
+# `azd env new <name>` before deploy.sh to use a different name.
+if [ ! -d .azure ] || [ -z "$(ls -A .azure 2>/dev/null)" ]; then
+  azd env new demo >/dev/null
+fi
 
 # Default AZURE_LOCATION to swedencentral if not already set. Sweden Central is
 # the only region in our supported list that ALSO supports Foundry hosted

--- a/microsoft-foundry/infra/hooks/preprovision.sh
+++ b/microsoft-foundry/infra/hooks/preprovision.sh
@@ -1,28 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Skip in non-interactive contexts (CI, piped stdin).
-[ -t 0 ] && [ -t 1 ] || exit 0
-
-# If CREATE_FOUNDRY_PROJECT is already set in this azd env, don't re-prompt.
+# Default: provision Foundry alongside the Neo4j MCP server. Override with:
+#   azd env set CREATE_FOUNDRY_PROJECT false
+# before re-running ./deploy.sh.
 existing="$(azd env get-value CREATE_FOUNDRY_PROJECT 2>/dev/null || true)"
 case "$existing" in
   true|false) exit 0 ;;
 esac
-
-cat <<'INFO'
-
-Microsoft Foundry provisioning
-  Provisions a Foundry account, project, and a gpt-4o-mini model
-  deployment in the same resource group, plus an Azure AI Developer
-  role assignment for you so `az login` is all the auth examples need.
-  Skip this if you already have a Foundry project to use instead.
-
-INFO
-
-read -r -p "Provision Microsoft Foundry too? [Y/n] " response
-response_lc="$(printf '%s' "$response" | tr '[:upper:]' '[:lower:]')"
-case "$response_lc" in
-  n|no) azd env set CREATE_FOUNDRY_PROJECT false ;;
-  *)    azd env set CREATE_FOUNDRY_PROJECT true ;;
-esac
+azd env set CREATE_FOUNDRY_PROJECT true


### PR DESCRIPTION
## Summary
- **`deploy.sh`**: fail fast on stale `azd` auth instead of hanging on an interactive token refresh; default the azd env to `demo` via a filesystem check (no side effects) so `azd up` doesn't prompt for an env name on a fresh shell.
- **`hooks/preprovision.sh`**: drop the interactive Foundry prompt that hung silently in Azure Cloud Shell (azd buffers hook stdio there, so `read -p` blocked forever). Defaults to provisioning Foundry; override with `azd env set CREATE_FOUNDRY_PROJECT false`.
- **READMEs** (`microsoft-foundry`, `microsoft-agent-framework`): lead Quick Start with the repo clone and switch to the single-login pattern (`azd config set auth.useAzCliAuth true` + `az login`) so users landing on the docs via search get a complete, copy-pasteable path.

## Why
Demoing in Cloud Shell hit two silent hangs in a row: `azd up` waiting on an env-name prompt, then the preprovision hook waiting on a Foundry y/n that the user never saw. Neither failure mode surfaced any output, which is the worst possible UX for a demo.