### PR TITLE
Mention Neo4j Aura-hosted MCP in Foundry README

### DIFF
--- a/microsoft-foundry/README.md
+++ b/microsoft-foundry/README.md
@@ -20,6 +20,8 @@ flowchart LR
 
 The MCP path is shared infrastructure: deploy once, attach from Foundry, Copilot Studio, Microsoft Agent Framework, or any MCP client. The function-tool path keeps Neo4j access inside your application boundary when you need tighter control over Cypher, secrets, and audit.
 
+> **Neo4j Aura-hosted MCP.** [Aura](https://neo4j.com/docs/mcp/current/mcp-for-aura/) now ships a built-in MCP endpoint per instance — no self-hosting needed. It authenticates with OAuth 2.0 Dynamic Client Registration (DCR), which the Foundry **portal** doesn't support for MCP tools yet. Attach it from [Microsoft Agent Framework](../microsoft-agent-framework/) (DCR-capable); in the Foundry portal, use the self-hosted MCP here.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Neo4j Aura now ships a built-in MCP endpoint per instance, so people can skip self-hosting. Adds a short note in the Foundry README pointing to it.

Caveat worth flagging up front: it uses OAuth 2.0 DCR, which the Foundry portal doesn't support for MCP tools yet — so the note routes portal users to the self-hosted server and Aura-hosted users to Microsoft Agent Framework.

A full Agent Framework + Aura-hosted MCP walkthrough will follow in a separate PR.