### PR TITLE
showcasing graphrag integration with adk

### DIFF
--- a/google-adk/README.md
+++ b/google-adk/README.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-**Google ADK** (Agent Development Kit) is a powerful framework for building generative AI agents. This integration repository demonstrates how to build context-aware, enterprise-grade agents by connecting Google ADK to Neo4j using three distinct patterns:
+**Google ADK** (Agent Development Kit) is a powerful framework for building generative AI agents. This integration repository demonstrates how to build context-aware, enterprise-grade agents by connecting Google ADK to Neo4j using four distinct patterns:
 
 
 **1. Operational Database Access (via MCP):** Allows the agent to query, introspect, and interact with your primary Neo4j knowledge graph using the [Neo4j MCP server](https://neo4j.com/docs/mcp/current/).  
 **2. Persistent Agent Memory (via ADK MemoryService):** Equips the agent with stateful, long-term memory using `neo4j-agent-memory`, automatically extracting and storing conversational facts and entities into a dedicated Neo4j memory graph.  
 **3. Managed Agent Memory (via NAMS):** Offloads memory infrastructure entirely using the cloud-managed [Neo4j Agent Memory Service (NAMS)](https://memory.neo4jlabs.com/docs), accessible via REST API or directly as an MCP tool.  
+**4. Semantic Retrieval (via neo4j-graphrag):** Gives the agent vector, full-text, and hybrid search over unstructured content in the graph using [`neo4j-graphrag`](https://neo4j.com/docs/neo4j-graphrag-python/current/), with retrievers exposed as ADK tools.  
 
 Examples target **ADK 2.0**, which introduces graph-based workflows alongside the conversational agent model.
 
@@ -17,6 +18,7 @@ Examples target **ADK 2.0**, which introduces graph-based workflows alongside th
 **Standardized Tooling:** Connect Google ADK agents to Neo4j securely via the Model Context Protocol (MCP).  
 **Graph Introspection:** Allow agents to autonomously discover graph schemas and execute Cypher queries.  
 **Deterministic Workflows:** Use ADK 2.0 `Workflow` graphs to put generated Cypher through validation and routing that the model cannot skip.  
+**GraphRAG Retrieval:** Combine vector similarity with graph traversal so retrieved text arrives with the surrounding relationships, dates, and verifiable source IDs.  
 **Stateful Conversations:** Utilize Neo4j as a persistent memory layer to cure LLM "context amnesia."  
 **Multi-Stage Extraction:** Automatically extract entities, facts, and user preferences from conversations into a structured knowledge graph.  
 
@@ -30,6 +32,12 @@ To run the full architecture (MCP + Memory), install the following dependencies:
 ```bash
 pip install "google-adk>=2.0.0" neo4j-mcp-server "neo4j-agent-memory[google-adk,vertex-ai]" spacy
 python -m spacy download en_core_web_sm
+```
+
+For the GraphRAG retrieval examples:
+
+```bash
+pip install "google-adk>=2.0.0" neo4j-graphrag sentence-transformers
 ```
 
 ## Configuration & Authentication  
@@ -204,16 +212,58 @@ workflow = Workflow(
 ```
 
 > Annotate node parameters as `str | None`. A routing `Event` carries no payload, so a downstream node bound to a bare `str` receives `None` and fails input validation.
-  
-## Example  
+
+**5. GraphRAG Retrieval as an ADK Tool**  
+`neo4j-graphrag` retrievers turn a question into graph results. `HybridCypherRetriever` combines vector and full-text search, then runs a `retrieval_query` that traverses outward from each match — so retrieved text arrives with its source article, date, and related entities. Wrapping the retriever in a `FunctionTool` lets the agent choose it like any other tool.  
+
+```python
+from google.adk.tools.function_tool import FunctionTool
+from neo4j_graphrag.embeddings import SentenceTransformerEmbeddings
+from neo4j_graphrag.retrievers import HybridCypherRetriever
+
+# `node` and `score` are in scope: continue into the graph from each vector hit.
+RETRIEVAL_QUERY = """
+WITH node AS chunk, score
+MATCH (article:Article)-[:HAS_CHUNK]->(chunk)
+OPTIONAL MATCH (article)-[:MENTIONS]->(org:Organization)
+RETURN chunk.text AS text, article.id AS article_id, article.title AS title,
+       collect(DISTINCT org.name)[..5] AS companies, score
+"""
+
+retriever = HybridCypherRetriever(
+    driver=driver,
+    vector_index_name="news_sbert",
+    fulltext_index_name="news_fulltext",
+    retrieval_query=RETRIEVAL_QUERY,
+    embedder=SentenceTransformerEmbeddings(),
+)
+
+def search_news(question: str) -> str:
+    """Search news by meaning and return the source article and companies mentioned.
+
+    Args:
+        question: A natural-language description of what to look for.
+    """
+    result = retriever.search(query_text=question, top_k=5)
+    return json.dumps([item.content for item in result.items])
+
+agent = Agent(model="gemini-3-flash", name="news_analyst",
+              tools=[FunctionTool(search_news)])
+```
+
+> The embedding model must match the model that built the vector index. A mismatch does not raise an error — it silently returns meaningless results. Re-embed a stored chunk and compare against its saved vector to confirm the pairing.
+
+## Example
 
 | Notebook | Description |
 |----------|-------------|
 | [google_adk.ipynb](https://github.com/neo4j-labs/neo4j-agent-integrations/blob/main/google-adk/google_adk.ipynb) | Walkthrough of using Google ADK with Neo4j MCP: agent setup, Cypher query execution, deterministic workflows, and utilising persistent graph memory for agent |
-  
+| [neo4j_graphrag_adk.ipynb](https://github.com/neo4j-labs/neo4j-agent-integrations/blob/main/google-adk/neo4j_graphrag_adk.ipynb) | Walkthrough of using `neo4j-graphrag` with Google ADK: pairing embedding models with vector indexes, vector, hybrid and graph-traversal retrievers, and exposing them as agent tools |
+
 ## Resources  
 • [Neo4j MCP Server Documentation](https://neo4j.com/docs/mcp/current/)
 • [Google ADK Official Documentation](https://docs.cloud.google.com/agent-builder/agent-development-kit/overview)
 • [ADK 2.0 Graph Workflows](https://adk.dev/graphs/)
+• [Neo4j GraphRAG for Python](https://neo4j.com/docs/neo4j-graphrag-python/current/)
 • [Neo4j Agent Memory](https://neo4j.com/labs/agent-memory/)
 • [Neo4j Agent Memory Service (NAMS)](https://memory.neo4jlabs.com/docs)

--- a/google-adk/neo4j_graphrag_adk.ipynb
+++ b/google-adk/neo4j_graphrag_adk.ipynb
@@ -1,0 +1,1039 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2bfd81c1",
+   "metadata": {},
+   "source": [
+    "# Neo4j GraphRAG + Google ADK\n",
+    "\n",
+    "`neo4j-graphrag` is Neo4j's official retrieval library. It provides **retrievers** — objects that\n",
+    "turn a question into results from your graph using vector search, full-text search, graph\n",
+    "traversal, or a combination of all three.\n",
+    "\n",
+    "This notebook connects those retrievers to a Google ADK agent, so the agent picks a retrieval\n",
+    "strategy the way it would pick any other tool.\n",
+    "\n",
+    "| | |\n",
+    "| --- | --- |\n",
+    "| **`neo4j-graphrag`** | Retrieval — finding the right context in the graph |\n",
+    "| **Google ADK** | Orchestration — deciding what to retrieve, and writing the answer |\n",
+    "\n",
+    "Contents:\n",
+    "\n",
+    "1. Pairing an embedding model with a vector index\n",
+    "2. `VectorRetriever` — semantic search over text\n",
+    "3. `VectorCypherRetriever` — semantic search that continues into the graph\n",
+    "4. `HybridRetriever` — semantic and keyword search combined\n",
+    "5. Retrievers as ADK tools, chosen by an agent\n",
+    "\n",
+    "Everything runs against the public Neo4j demo database. You need a Gemini API key and nothing else."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab6c7fcc",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d13a8db2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m26.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.2.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -q \"google-adk>=2.0.0\" neo4j-graphrag neo4j sentence-transformers google-genai aiohttp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b34638e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "os.environ[\"PYDANTIC_DISABLE_PLUGINS\"] = \"1\"\n",
+    "\n",
+    "import json\n",
+    "import logging\n",
+    "import math\n",
+    "import warnings\n",
+    "from getpass import getpass\n",
+    "\n",
+    "import neo4j\n",
+    "from neo4j import GraphDatabase\n",
+    "\n",
+    "from neo4j_graphrag.embeddings import SentenceTransformerEmbeddings\n",
+    "from neo4j_graphrag.retrievers import (\n",
+    "    VectorRetriever,\n",
+    "    VectorCypherRetriever,\n",
+    "    HybridRetriever,\n",
+    "    HybridCypherRetriever,\n",
+    ")\n",
+    "from neo4j_graphrag.types import RetrieverResultItem\n",
+    "\n",
+    "from google.genai import types\n",
+    "from google.adk import Agent\n",
+    "from google.adk.apps import App\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.adk.tools.function_tool import FunctionTool\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "logging.getLogger(\"neo4j.notifications\").setLevel(logging.ERROR)\n",
+    "\n",
+    "print(\"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bfdda87f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"GOOGLE_API_KEY\"] = getpass(\"Enter Google API Key: \")\n",
+    "\n",
+    "GEMINI_MODEL = \"gemini-flash-latest\"\n",
+    "\n",
+    "NEO4J_URI = \"neo4j+s://demo.neo4jlabs.com\"\n",
+    "NEO4J_DATABASE = \"companies\"\n",
+    "NEO4J_USERNAME = \"companies\"\n",
+    "NEO4J_PASSWORD = \"companies\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fe29cf0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to companies\n"
+     ]
+    }
+   ],
+   "source": [
+    "driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))\n",
+    "print(\"Connected to\", NEO4J_DATABASE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90e56993",
+   "metadata": {},
+   "source": [
+    "### Cypher version\n",
+    "\n",
+    "`neo4j-graphrag` generates its vector searches using the Cypher 25 `SEARCH` clause. The demo\n",
+    "database understands Cypher 25 but still defaults to Cypher 5, so we prefix the generated queries\n",
+    "to select the newer language version.\n",
+    "\n",
+    "If your own database already defaults to Cypher 25 — set with\n",
+    "`ALTER DATABASE ... SET DEFAULT LANGUAGE CYPHER 25` — you can skip this cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "140473f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated vector queries will run as Cypher 25.\n"
+     ]
+    }
+   ],
+   "source": [
+    "_execute_query = neo4j.Driver.execute_query\n",
+    "\n",
+    "\n",
+    "if not getattr(neo4j.Driver.execute_query, \"_cypher25_patch\", False):\n",
+    "    _execute_query = neo4j.Driver.execute_query\n",
+    "\n",
+    "    def _execute_query_cypher25(self, query, *args, **kwargs):\n",
+    "        if isinstance(query, str) and \"VECTOR INDEX\" in query.upper() \\\n",
+    "                and not query.lstrip().upper().startswith(\"CYPHER\"):\n",
+    "            query = \"CYPHER 25 \" + query\n",
+    "        return _execute_query(self, query, *args, **kwargs)\n",
+    "\n",
+    "    _execute_query_cypher25._cypher25_patch = True\n",
+    "    neo4j.Driver.execute_query = _execute_query_cypher25\n",
+    "\n",
+    "print(\"Generated vector queries will run as Cypher 25.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41b9a939",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. The graph\n",
+    "\n",
+    "The demo `companies` database holds news articles about public companies. Each article is split\n",
+    "into `Chunk` nodes that carry the text and its embeddings, and is linked to the organizations it\n",
+    "mentions:\n",
+    "\n",
+    "```\n",
+    "(Article)-[:HAS_CHUNK]->(Chunk)\n",
+    "(Article)-[:MENTIONS]->(Organization)\n",
+    "(Organization)-[:HAS_COMPETITOR|HAS_INVESTOR|HAS_SUPPLIER]->(Organization)\n",
+    "```\n",
+    "\n",
+    "That shape is what makes graph retrieval worthwhile. A vector search finds a *chunk* — but the\n",
+    "article it belongs to, its publication date, its sentiment score, and the companies it discusses\n",
+    "are all one hop away."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "068f00e2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Pair the embedding model with the index\n",
+    "\n",
+    "A vector index stores embeddings produced by one specific model. Querying it with a different\n",
+    "model still returns results, but they are meaningless: two models place the same text at\n",
+    "different points in space, so the similarity scores are noise.\n",
+    "\n",
+    "Nothing raises an exception when this happens, which makes it the most common way a GraphRAG\n",
+    "setup silently underperforms. So start by looking at what indexes exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8ea8dfa0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  news_fulltext      FULLTEXT  ['text']                   -\n",
+      "  news               VECTOR    ['embedding']              1536 dims\n",
+      "  news_google        VECTOR    ['embedding_google']       768 dims\n",
+      "  news_google_004    VECTOR    ['embedding_google_004']   768 dims\n",
+      "  news_sbert         VECTOR    ['embedding_sbert']        384 dims\n"
+     ]
+    }
+   ],
+   "source": [
+    "indexes, _, _ = driver.execute_query(\n",
+    "    \"\"\"\n",
+    "    SHOW INDEXES YIELD name, type, labelsOrTypes, properties, options\n",
+    "    WHERE type IN ['VECTOR', 'FULLTEXT'] AND labelsOrTypes = ['Chunk']\n",
+    "    RETURN name, type, properties,\n",
+    "           options.indexConfig['vector.dimensions'] AS dimensions\n",
+    "    ORDER BY type, name\n",
+    "    \"\"\",\n",
+    "    database_=NEO4J_DATABASE,\n",
+    ")\n",
+    "\n",
+    "for record in indexes:\n",
+    "    row = record.data()\n",
+    "    dims = f\"{row['dimensions']} dims\" if row[\"dimensions\"] else \"-\"\n",
+    "    print(f\"  {row['name']:<18} {row['type']:<9} {str(row['properties']):<26} {dims}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09e8cef5",
+   "metadata": {},
+   "source": [
+    "The demo graph stores several embeddings of the same chunks, one per model, so you can pick\n",
+    "whichever you have access to.\n",
+    "\n",
+    "We use **`news_sbert`** with `SentenceTransformerEmbeddings`. Its 384 dimensions correspond to\n",
+    "`all-MiniLM-L6-v2`, the library's default sentence-transformers model, so the pairing is exact.\n",
+    "It also runs locally, which means no API key, no quota, and identical results every time you run\n",
+    "this notebook.\n",
+    "\n",
+    "**`news_fulltext`** indexes the `text` property on those same `Chunk` nodes. Hybrid retrieval\n",
+    "needs a vector index and a full-text index over the same nodes, so this pairing is what makes\n",
+    "section 6 possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "36350de0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "384 dimensions\n"
+     ]
+    }
+   ],
+   "source": [
+    "VECTOR_INDEX = \"news_sbert\"\n",
+    "FULLTEXT_INDEX = \"news_fulltext\"\n",
+    "\n",
+    "# Downloads all-MiniLM-L6-v2 on first use (about 90 MB).\n",
+    "embedder = SentenceTransformerEmbeddings()\n",
+    "\n",
+    "print(f\"{len(embedder.embed_query('test'))} dimensions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be51f7a8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. `VectorRetriever` — semantic search\n",
+    "\n",
+    "The simplest retriever. Give it a driver, an index name, and an embedder; it embeds the question,\n",
+    "searches the index, and returns matching nodes.\n",
+    "\n",
+    "Set `return_properties` to control what comes back. Without it you get whole nodes — embeddings\n",
+    "included, which is thousands of floats per result heading straight into your prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "beeb502d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {'text': 'Summary\\nRenewable energy\\'s growth potential is booming\\nEPS increases as revenue misses estimates, risk is still in the air\\nConfident management wi...\n",
+      "\n",
+      "  {'text': 'Microsoft has attempted to expand its energy portfolio on several occasions this year by entering into partnerships with various firms. These include ...\n",
+      "\n",
+      "  {'text': 'From pv magazine USA\\nIn a quarterly report on large-scale renewable energy power purchase agreements (PPA), energy advisory Edison Energy said prices...\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "vector_retriever = VectorRetriever(\n",
+    "    driver=driver,\n",
+    "    index_name=VECTOR_INDEX,\n",
+    "    embedder=embedder,\n",
+    "    return_properties=[\"text\"],\n",
+    "    neo4j_database=NEO4J_DATABASE,\n",
+    ")\n",
+    "\n",
+    "QUERY = \"renewable energy investment\"\n",
+    "\n",
+    "for item in vector_retriever.search(query_text=QUERY, top_k=3).items:\n",
+    "    print(f\"  {item.content[:160]}...\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aef48dc8",
+   "metadata": {},
+   "source": [
+    "This is ordinary RAG: it finds relevant text and stops. The retriever knows a chunk matched, but\n",
+    "not which article it came from, when it was published, or which companies it discusses."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e33d929f",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. `VectorCypherRetriever` — retrieval that continues into the graph\n",
+    "\n",
+    "This is the retriever that separates GraphRAG from RAG.\n",
+    "\n",
+    "It runs the same vector search, then executes a `retrieval_query` starting from each match. Two\n",
+    "variables are in scope for that query: `node`, the node found by the vector search, and `score`,\n",
+    "its similarity. From there you can traverse anywhere in the graph.\n",
+    "\n",
+    "Below: chunk → article (title, date, sentiment) → organizations mentioned → their competitors.\n",
+    "The model receives the text *and* the surrounding facts in a single round trip.\n",
+    "\n",
+    "A `result_formatter` turns each returned record into whatever shape you want. Without one you get\n",
+    "the driver's default record repr, which is awkward to read and awkward to hand to a model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "91bce730",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  NextEra Energy Partners: Winds In The Sails?  (2018-10-25T07:09:00Z, sentiment 0.0)\n",
+      "    companies: ['BlackBerry', 'Sails', 'YCharts']\n",
+      "    competitors: []\n",
+      "    Summary\n",
+      "Renewable energy's growth potential is booming\n",
+      "EPS increases as revenue misses estimates, risk is still in the a...\n",
+      "\n",
+      "  Microsoft announces renewable energy initiatives in collaboration with ENGIE  (2019-09-24T17:10:00Z, sentiment 0.866)\n",
+      "    companies: ['Microsoft France', 'Microsoft', 'Microsoft Azure']\n",
+      "    competitors: []\n",
+      "    Microsoft has attempted to expand its energy portfolio on several occasions this year by entering into partnerships with...\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "RETRIEVAL_QUERY = \"\"\"\n",
+    "WITH node AS chunk, score\n",
+    "MATCH (article:Article)-[:HAS_CHUNK]->(chunk)\n",
+    "OPTIONAL MATCH (article)-[:MENTIONS]->(org:Organization)\n",
+    "OPTIONAL MATCH (org)-[:HAS_COMPETITOR]->(rival:Organization)\n",
+    "RETURN chunk.text             AS text,\n",
+    "       article.id             AS article_id,\n",
+    "       article.title          AS title,\n",
+    "       toString(article.date) AS date,\n",
+    "       article.sentiment      AS sentiment,\n",
+    "       collect(DISTINCT org.name)[..5]   AS companies,\n",
+    "       collect(DISTINCT rival.name)[..5] AS competitors,\n",
+    "       score\n",
+    "ORDER BY score DESC\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "def format_record(record) -> RetrieverResultItem:\n",
+    "    \"\"\"Shape each result into compact JSON for the model.\"\"\"\n",
+    "    return RetrieverResultItem(\n",
+    "        content=json.dumps({\n",
+    "            \"text\": (record.get(\"text\") or \"\")[:600],\n",
+    "            \"article_id\": record.get(\"article_id\"),\n",
+    "            \"title\": record.get(\"title\"),\n",
+    "            \"date\": record.get(\"date\"),\n",
+    "            \"sentiment\": record.get(\"sentiment\"),\n",
+    "            \"companies\": record.get(\"companies\"),\n",
+    "            \"competitors\": record.get(\"competitors\"),\n",
+    "        }, default=str),\n",
+    "        metadata={\"score\": record.get(\"score\")},\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "graph_retriever = VectorCypherRetriever(\n",
+    "    driver=driver,\n",
+    "    index_name=VECTOR_INDEX,\n",
+    "    retrieval_query=RETRIEVAL_QUERY,\n",
+    "    embedder=embedder,\n",
+    "    result_formatter=format_record,\n",
+    "    neo4j_database=NEO4J_DATABASE,\n",
+    ")\n",
+    "\n",
+    "for item in graph_retriever.search(query_text=QUERY, top_k=2).items:\n",
+    "    row = json.loads(item.content)\n",
+    "    print(f\"  {row['title']}  ({row['date']}, sentiment {row['sentiment']})\")\n",
+    "    print(f\"    companies: {row['companies']}\")\n",
+    "    print(f\"    competitors: {row['competitors']}\")\n",
+    "    print(f\"    {row['text'][:120]}...\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57a91519",
+   "metadata": {},
+   "source": [
+    "Same query and same index as section 4, but every result now carries an article ID, a date, a\n",
+    "stored sentiment score, and the companies involved. That buys three things plain vector search\n",
+    "cannot offer:\n",
+    "\n",
+    "* **Citations you can check.** `article_id` is a real node, so a claim can be traced back to its\n",
+    "  source and verified.\n",
+    "* **Facts the text never states.** A competitor relationship lives in the graph, not in the\n",
+    "  article body.\n",
+    "* **Structure to filter and rank on.** Date, sentiment, and relationships are all available after\n",
+    "  the semantic match."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d1015f3",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6. `HybridRetriever` — semantic plus keyword\n",
+    "\n",
+    "Vector search is strong on meaning and weak on exact strings. Ask about a specific company,\n",
+    "ticker, or product and it tends to return material on the right *topic* while missing the\n",
+    "document that names it outright.\n",
+    "\n",
+    "Full-text search has the opposite profile: exact terms, no understanding of meaning.\n",
+    "\n",
+    "`HybridRetriever` runs both and merges the rankings, which recovers the exact matches without\n",
+    "losing the semantic ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c7d1fd54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- vector only ---\n",
+      "  {'text': ' DELL) helps organizations and individuals build their digital future and transform how they work, live and pl...\n",
+      "  {'text': '. Traditional GPU uses include professional visualization applications that require realistic rendering, inclu...\n",
+      "  {'text': ' Nvidia GPU Cloud (NGC) runs on the company’s distribution of Docker containers and is touted as “purpose buil...\n",
+      "\n",
+      "--- hybrid ---\n",
+      "  {'text': 'Supermicro Founder and CEO Charles Liang Will be Joined by Jensen Huang, NVIDIA CEO, and other Industry Lumina...\n",
+      "  {'text': ' DELL) helps organizations and individuals build their digital future and transform how they work, live and pl...\n",
+      "  {'text': 'Supermicro Founder and CEO Charles Liang Will be Joined by Jensen Huang, NVIDIA CEO, and other Industry Lumina...\n"
+     ]
+    }
+   ],
+   "source": [
+    "hybrid_retriever = HybridRetriever(\n",
+    "    driver=driver,\n",
+    "    vector_index_name=VECTOR_INDEX,\n",
+    "    fulltext_index_name=FULLTEXT_INDEX,\n",
+    "    embedder=embedder,\n",
+    "    return_properties=[\"text\"],\n",
+    "    neo4j_database=NEO4J_DATABASE,\n",
+    ")\n",
+    "\n",
+    "NAMED_QUERY = \"Nvidia data center GPU demand\"\n",
+    "\n",
+    "print(\"--- vector only ---\")\n",
+    "for item in vector_retriever.search(query_text=NAMED_QUERY, top_k=3).items:\n",
+    "    print(f\"  {item.content[:120]}...\")\n",
+    "\n",
+    "print(\"\\n--- hybrid ---\")\n",
+    "for item in hybrid_retriever.search(query_text=NAMED_QUERY, top_k=3).items:\n",
+    "    print(f\"  {item.content[:120]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02ade8e8",
+   "metadata": {},
+   "source": [
+    "The hybrid results surface chunks naming the company directly, while vector-only results drift\n",
+    "toward the general theme. The more distinctive the term — proper nouns, tickers, product codes —\n",
+    "the wider the gap.\n",
+    "\n",
+    "`HybridCypherRetriever` combines both ideas: hybrid search plus a `retrieval_query`. It is the\n",
+    "one to reach for in practice, and the one we give the agent below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e7b738ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"text\": \"Nvidia (NVDA) is an American technology company. It designs, manufactures, and sells graphic processors and related software. The company is credited with inventing the graphics processing unit (GPU) that is used in computers and other electronics. Originally a private company, Nvidia now trades as a publicly-traded company. Since then, its products have powered a variety of computer devices. It has even moved into newer technologies, including artificial intelligence and virtual reality.\\nThe company is among the few graphic chip companies from the 1990s that is still in business\n"
+     ]
+    }
+   ],
+   "source": [
+    "hybrid_graph_retriever = HybridCypherRetriever(\n",
+    "    driver=driver,\n",
+    "    vector_index_name=VECTOR_INDEX,\n",
+    "    fulltext_index_name=FULLTEXT_INDEX,\n",
+    "    retrieval_query=RETRIEVAL_QUERY,\n",
+    "    embedder=embedder,\n",
+    "    result_formatter=format_record,\n",
+    "    neo4j_database=NEO4J_DATABASE,\n",
+    ")\n",
+    "\n",
+    "row = json.loads(hybrid_graph_retriever.search(query_text=NAMED_QUERY, top_k=1).items[0].content)\n",
+    "print(json.dumps(row, indent=2)[:600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ffeda9d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 7. Retrievers as ADK tools\n",
+    "\n",
+    "A retriever is a Python object with a `search()` method, so exposing one to an agent means\n",
+    "wrapping it in a function. ADK builds the tool schema from the function's name, type hints, and\n",
+    "docstring — so **the docstring is the interface**. It is how the model decides which retriever\n",
+    "fits the question in front of it.\n",
+    "\n",
+    "`neo4j-graphrag` also offers `retriever.convert_to_tool()`, which targets its own `ToolsRetriever`\n",
+    "and LLM tool-calling. For ADK, a plain function plus `FunctionTool` is the direct path.\n",
+    "\n",
+    "Below, three retrieval strategies with genuinely different strengths, and an agent that chooses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e98fab52",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent ready with 3 retrieval strategies.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def search_news(question: str) -> str:\n",
+    "    \"\"\"Search news article text by meaning. Best for broad themes and open-ended questions,\n",
+    "    for example \"what are the concerns around AI regulation\".\n",
+    "\n",
+    "    Args:\n",
+    "        question: A natural-language description of what to look for.\n",
+    "\n",
+    "    Returns:\n",
+    "        JSON list of matching text passages.\n",
+    "    \"\"\"\n",
+    "    result = vector_retriever.search(query_text=question, top_k=5)\n",
+    "    return json.dumps([item.content for item in result.items], indent=2)\n",
+    "\n",
+    "\n",
+    "def search_news_with_context(question: str) -> str:\n",
+    "    \"\"\"Search news by meaning and return graph context with each result: the source article,\n",
+    "    its date and sentiment, the companies mentioned, and their competitors. Use this whenever\n",
+    "    the answer needs citations or company relationships.\n",
+    "\n",
+    "    Args:\n",
+    "        question: A natural-language description of what to look for.\n",
+    "\n",
+    "    Returns:\n",
+    "        JSON list of passages with article_id, title, date, sentiment, companies, competitors.\n",
+    "    \"\"\"\n",
+    "    result = hybrid_graph_retriever.search(query_text=question, top_k=5)\n",
+    "    return json.dumps([json.loads(item.content) for item in result.items], indent=2)\n",
+    "\n",
+    "\n",
+    "def find_named_entity(question: str) -> str:\n",
+    "    \"\"\"Search news for an exact company name, ticker, or product that appears literally in the\n",
+    "    text. Use this when the question centres on a specific named thing rather than a theme.\n",
+    "\n",
+    "    Args:\n",
+    "        question: The name or phrase to find, with any surrounding context.\n",
+    "\n",
+    "    Returns:\n",
+    "        JSON list of matching text passages.\n",
+    "    \"\"\"\n",
+    "    result = hybrid_retriever.search(query_text=question, top_k=5)\n",
+    "    return json.dumps([item.content for item in result.items], indent=2)\n",
+    "\n",
+    "\n",
+    "graphrag_app = App(\n",
+    "    name=\"graphrag_app\",\n",
+    "    root_agent=Agent(\n",
+    "        name=\"news_analyst\",\n",
+    "        model=GEMINI_MODEL,\n",
+    "        instruction=\"\"\"You answer questions about companies using a Neo4j news graph.\n",
+    "\n",
+    "Choose the retrieval tool that fits the question:\n",
+    "- `search_news` for broad themes and open-ended topics.\n",
+    "- `search_news_with_context` when the answer needs citations, dates, sentiment, or company\n",
+    "  relationships. Prefer this one for anything analytical.\n",
+    "- `find_named_entity` when the question is about a specific named company, ticker, or product.\n",
+    "\n",
+    "Cite the article title and date when the tool provides them. If the retrieved passages do not\n",
+    "answer the question, say so rather than filling the gap from your own knowledge.\n",
+    "\"\"\",\n",
+    "        tools=[\n",
+    "            FunctionTool(search_news),\n",
+    "            FunctionTool(search_news_with_context),\n",
+    "            FunctionTool(find_named_entity),\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(\"Agent ready with 3 retrieval strategies.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "753df50b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def ask(app, query, show_tools=True):\n",
+    "    sessions = InMemorySessionService()\n",
+    "    session = await sessions.create_session(state={}, app_name=app.name, user_id=\"user_1\")\n",
+    "    runner = Runner(app=app, session_service=sessions)\n",
+    "\n",
+    "    print(f\"USER: {query}\")\n",
+    "    answer = \"\"\n",
+    "\n",
+    "    async for event in runner.run_async(\n",
+    "        session_id=session.id,\n",
+    "        user_id=session.user_id,\n",
+    "        new_message=types.Content(role=\"user\", parts=[types.Part(text=query)]),\n",
+    "    ):\n",
+    "        if not getattr(event, \"content\", None) or not event.content.parts:\n",
+    "            continue\n",
+    "        for part in event.content.parts:\n",
+    "            if part.function_call and show_tools:\n",
+    "                args = json.dumps(part.function_call.args, default=str)[:110]\n",
+    "                print(f\"   -> {part.function_call.name}({args})\")\n",
+    "            elif part.function_response and show_tools:\n",
+    "                print(f\"   <- {part.function_response.name}\")\n",
+    "            elif part.text:\n",
+    "                answer += part.text\n",
+    "\n",
+    "    print(f\"\\nAGENT: {answer.strip()}\\n\")\n",
+    "    return answer.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e518e6b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "USER: Which companies are expanding in renewable energy, and who competes with them?\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   -> search_news_with_context({\"question\": \"companies expanding in renewable energy\"})\n",
+      "   <- search_news_with_context\n",
+      "   -> search_news_with_context({\"question\": \"renewable energy competitors\"})\n",
+      "   <- search_news_with_context\n",
+      "   -> search_news_with_context({\"question\": \"solar wind clean energy utility expansion\"})\n",
+      "   <- search_news_with_context\n",
+      "\n",
+      "AGENT: Based on the news graph, several companies are actively expanding in the renewable energy sector, along with their key competitors:\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 1. **Invenergy**\n",
+      "* **Expansion Activities**: Developing and expanding large-scale wind and solar projects, such as the 103.9-megawatt Number Three Wind Energy Center—the first operational project in the 3,800 MW Clean Path NY renewable portfolio.\n",
+      "* **Competitors**: **Tesla**\n",
+      "* **Source**: *\"Invenergy and Clean Path NY Partners, energyRe and New York Power Authority, Celebrate the Completion of Number Three Wind Energy Center, Marking Progress for New York State Climate Goals\"* (May 4, 2023 / May 5, 2023)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 2. **MidAmerican Energy Company**\n",
+      "* **Expansion / Transition Activities**: Transitioning capacity toward cleaner alternatives, including solar and battery storage.\n",
+      "* **Competitors**: **Alliant Energy Corporation**, **Duke Energy**\n",
+      "* **Source**: *\"Two Big Wins in Iowa\"* (May 16, 2023)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 3. **EDP Renovaveis SA (EDPR)**\n",
+      "* **Expansion Activities**: Planning to invest €21 billion (~$23.12 billion) over four years in renewable energy across North America, Europe, and the Asia-Pacific region, including direct power purchase agreements in Japan and Korea.\n",
+      "* **Source**: *\"EDP plans wider Asian role with renewable power supplies to Japan, Korea firms\"* (May 23, 2023)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 4. **AES / AES Clean Energy**\n",
+      "* **Expansion Activities**: Expanding a 1.3 GW grid-connected renewable energy portfolio comprising 17 solar projects and 1 wind project across six US states (with investment support from Hannon Armstrong).\n",
+      "* **Source**: *\"Hannon Armstrong invests in AES’ 1.3GW renewable portfolio\"* (January 5, 2023)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 5. **Additional Companies Expanding in Clean Energy**\n",
+      "* **Westbridge Renewable Energy Corporation**: Developing solar and battery storage capacity in Canada (*\"Westbridge Renewable Energy Corporation\"*, March 30, 2023).\n",
+      "* **NextEra Energy (NEE)**: Expanding utility-scale wind and solar operations across North America (*\"NextEra Energy Partners: Winds In The Sails?\"*, October 25, 2018).\n",
+      "* **Indian Renewable Operators**: Companies such as **ReNew Power**, **Adani Green Energy**, **Hero Future Energies**, **Greenko Group**, and **Orange Renewable** are competing and expanding wind and solar capacity across India (*\"Top 15 best Renewable Wind Energy companies in india 2023\"*, May 31, 2023).\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Based on the news graph, several companies are actively expanding in the renewable energy sector, along with their key competitors:\\n\\n---\\n\\n### 1. **Invenergy**\\n* **Expansion Activities**: Developing and expanding large-scale wind and solar projects, such as the 103.9-megawatt Number Three Wind Energy Center—the first operational project in the 3,800 MW Clean Path NY renewable portfolio.\\n* **Competitors**: **Tesla**\\n* **Source**: *\"Invenergy and Clean Path NY Partners, energyRe and New York Power Authority, Celebrate the Completion of Number Three Wind Energy Center, Marking Progress for New York State Climate Goals\"* (May 4, 2023 / May 5, 2023)\\n\\n---\\n\\n### 2. **MidAmerican Energy Company**\\n* **Expansion / Transition Activities**: Transitioning capacity toward cleaner alternatives, including solar and battery storage.\\n* **Competitors**: **Alliant Energy Corporation**, **Duke Energy**\\n* **Source**: *\"Two Big Wins in Iowa\"* (May 16, 2023)\\n\\n---\\n\\n### 3. **EDP Renovaveis SA (EDPR)**\\n* **Expansion Activities**: Planning to invest €21 billion (~$23.12 billion) over four years in renewable energy across North America, Europe, and the Asia-Pacific region, including direct power purchase agreements in Japan and Korea.\\n* **Source**: *\"EDP plans wider Asian role with renewable power supplies to Japan, Korea firms\"* (May 23, 2023)\\n\\n---\\n\\n### 4. **AES / AES Clean Energy**\\n* **Expansion Activities**: Expanding a 1.3 GW grid-connected renewable energy portfolio comprising 17 solar projects and 1 wind project across six US states (with investment support from Hannon Armstrong).\\n* **Source**: *\"Hannon Armstrong invests in AES’ 1.3GW renewable portfolio\"* (January 5, 2023)\\n\\n---\\n\\n### 5. **Additional Companies Expanding in Clean Energy**\\n* **Westbridge Renewable Energy Corporation**: Developing solar and battery storage capacity in Canada (*\"Westbridge Renewable Energy Corporation\"*, March 30, 2023).\\n* **NextEra Energy (NEE)**: Expanding utility-scale wind and solar operations across North America (*\"NextEra Energy Partners: Winds In The Sails?\"*, October 25, 2018).\\n* **Indian Renewable Operators**: Companies such as **ReNew Power**, **Adani Green Energy**, **Hero Future Energies**, **Greenko Group**, and **Orange Renewable** are competing and expanding wind and solar capacity across India (*\"Top 15 best Renewable Wind Energy companies in india 2023\"*, May 31, 2023).'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Analytical question - needs relationships and citations.\n",
+    "await ask(graphrag_app,\n",
+    "          \"Which companies are expanding in renewable energy, and who competes with them?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e71b0bf1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "USER: What are the recent trends in cloud computing?\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   -> search_news_with_context({\"question\": \"recent trends in cloud computing\"})\n",
+      "   <- search_news_with_context\n",
+      "   -> search_news_with_context({\"question\": \"cloud computing trends technology innovations hybrid multicloud\"})\n",
+      "   <- search_news_with_context\n",
+      "\n",
+      "AGENT: Based on the news and industry reports, several key trends have characterized the cloud computing landscape:\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 1. **Multicloud Adoption and Containerization**\n",
+      "* **Containerization & Orchestration:** Technologies like Docker and Kubernetes have become central to cloud application delivery, enabling continuous integration and DevOps practices across diverse environments.\n",
+      "* **Multicloud Strategy:** Enterprises are increasingly investing in multicloud strategies to optimize flexibility and avoid vendor lock-in. However, industry research indicates that skills shortages and recruitment challenges remain significant hurdles to achieving full multicloud operational maturity.\n",
+      "  * *Citations:* \n",
+      "    * *\"Reasons to Opt for a Multicloud Strategy\"* (August 24, 2021)\n",
+      "    * *\"Skills shortages hold back enterprises from reaching multicloud goals\"* (June 13, 2023)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 2. **Expansion of Cloud-Enabling Technologies and Automation**\n",
+      "* **Automation & DevSecOps:** The market is seeing increased demand for cloud infrastructure automation, DevSecOps, compliance management platforms, and Service-Oriented Architecture (SOA) solutions to streamline complex deployments.\n",
+      "* **Edge & Distributed Infrastructure:** Cloud architectures are increasingly incorporating edge computing, hybrid cloud integrations, and centralized cloud management platforms.\n",
+      "  * *Citations:*\n",
+      "    * *\"Cloud-Enabling Technologies Market Size & Growth Trends 2029\"* (April 19, 2023)\n",
+      "    * *\"Oracle Cloud: The Simplest Explanation You’ll Ever Need\"* (June 15, 2023)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 3. **Hybrid Cloud as an Enterprise Standard**\n",
+      "* Hybrid cloud architecture continues to serve as a preferred deployment model, allowing organizations to maintain sensitive workloads behind private firewalls while leveraging the scalability and cost efficiency of public cloud providers.\n",
+      "  * *Citation:* *\"Navigating the hybrid highway\"* (December 18, 2014)\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### 4. **Shift to Utility-Based, On-Demand Infrastructure**\n",
+      "* Organizations continue to transition from local/on-premise storage and compute hardware to flexible, on-demand utility computing models and managed databases to enhance operational efficiency, security, and scalability.\n",
+      "  * *Citations:*\n",
+      "    * *\"Cloud Computing Service Market- Technology, Progression Status, Size, Share And Revenue Expectation To 2026\"* (September 4, 2020)\n",
+      "    * *\"Cloud Computing Solutions Market Expects +16% CAGR Growth by 2019-2026\"* (December 25, 2019)\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Based on the news and industry reports, several key trends have characterized the cloud computing landscape:\\n\\n---\\n\\n### 1. **Multicloud Adoption and Containerization**\\n* **Containerization & Orchestration:** Technologies like Docker and Kubernetes have become central to cloud application delivery, enabling continuous integration and DevOps practices across diverse environments.\\n* **Multicloud Strategy:** Enterprises are increasingly investing in multicloud strategies to optimize flexibility and avoid vendor lock-in. However, industry research indicates that skills shortages and recruitment challenges remain significant hurdles to achieving full multicloud operational maturity.\\n  * *Citations:* \\n    * *\"Reasons to Opt for a Multicloud Strategy\"* (August 24, 2021)\\n    * *\"Skills shortages hold back enterprises from reaching multicloud goals\"* (June 13, 2023)\\n\\n---\\n\\n### 2. **Expansion of Cloud-Enabling Technologies and Automation**\\n* **Automation & DevSecOps:** The market is seeing increased demand for cloud infrastructure automation, DevSecOps, compliance management platforms, and Service-Oriented Architecture (SOA) solutions to streamline complex deployments.\\n* **Edge & Distributed Infrastructure:** Cloud architectures are increasingly incorporating edge computing, hybrid cloud integrations, and centralized cloud management platforms.\\n  * *Citations:*\\n    * *\"Cloud-Enabling Technologies Market Size & Growth Trends 2029\"* (April 19, 2023)\\n    * *\"Oracle Cloud: The Simplest Explanation You’ll Ever Need\"* (June 15, 2023)\\n\\n---\\n\\n### 3. **Hybrid Cloud as an Enterprise Standard**\\n* Hybrid cloud architecture continues to serve as a preferred deployment model, allowing organizations to maintain sensitive workloads behind private firewalls while leveraging the scalability and cost efficiency of public cloud providers.\\n  * *Citation:* *\"Navigating the hybrid highway\"* (December 18, 2014)\\n\\n---\\n\\n### 4. **Shift to Utility-Based, On-Demand Infrastructure**\\n* Organizations continue to transition from local/on-premise storage and compute hardware to flexible, on-demand utility computing models and managed databases to enhance operational efficiency, security, and scalability.\\n  * *Citations:*\\n    * *\"Cloud Computing Service Market- Technology, Progression Status, Size, Share And Revenue Expectation To 2026\"* (September 4, 2020)\\n    * *\"Cloud Computing Solutions Market Expects +16% CAGR Growth by 2019-2026\"* (December 25, 2019)'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Broad thematic question - semantic search alone is enough.\n",
+    "await ask(graphrag_app, \"What are the recent trends in cloud computing?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22ab25a4",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 8. Comparing strategies side by side\n",
+    "\n",
+    "Tool choice is the agent's problem. Knowing which retriever suits *your* data is yours. Run all\n",
+    "three over one question and read the results together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "747036b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== vector ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {'text': '\"A significant portion of the rare-earth supply chain still resides in China, making it difficult to fully commit to \\'Made in America\\' in...\n",
+      "  {'text': '? What Will Be the Estimation of Cost and Profit? What Will Be Market Share, Supply and Consumption? What about Import and Export?\\n● Where...\n",
+      "\n",
+      "=== hybrid ===\n",
+      "  {'text': '\"A significant portion of the rare-earth supply chain still resides in China, making it difficult to fully commit to \\'Made in America\\' in...\n",
+      "  {'text': \"Following a DIGITIMES Asia report in mid-May indicating that Chinese foundry SMIC has removed its 14nm FinFET offering from its website, rec...\n",
+      "\n",
+      "=== hybrid + graph ===\n",
+      "  [Supply Chain Issues for 'Made in America' Semiconductors] \"A significant portion of the rare-earth supply chain still resides in China, making it difficult to fully commit to 'Made in Amer...\n",
+      "  [SMIC subsidiary continues to fulfill Chinese demands for FinFET capabilities] Following a DIGITIMES Asia report in mid-May indicating that Chinese foundry SMIC has removed its 14nm FinFET offering from its we...\n"
+     ]
+    }
+   ],
+   "source": [
+    "COMPARISON_QUERY = \"semiconductor manufacturing capacity\"\n",
+    "\n",
+    "for label, retriever in [\n",
+    "    (\"vector\", vector_retriever),\n",
+    "    (\"hybrid\", hybrid_retriever),\n",
+    "    (\"hybrid + graph\", hybrid_graph_retriever),\n",
+    "]:\n",
+    "    print(f\"\\n=== {label} ===\")\n",
+    "    for item in retriever.search(query_text=COMPARISON_QUERY, top_k=2).items:\n",
+    "        try:\n",
+    "            row = json.loads(item.content)\n",
+    "            print(f\"  [{row['title']}] {row['text'][:130].strip()}...\")\n",
+    "        except (json.JSONDecodeError, KeyError):\n",
+    "            print(f\"  {item.content[:150].strip()}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "815945d2",
+   "metadata": {},
+   "source": [
+    "Judge them on whether the retrieved passages would let a model answer your questions: recall\n",
+    "across the topic, precision on named entities, and whether the extra graph context justifies the\n",
+    "extra Cypher."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "704c80da",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 9. Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "8dbbbdc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Closed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "driver.close()\n",
+    "print(\"Closed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a169c7ea",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Summary\n",
+    "\n",
+    "**Retrievers are the unit of reuse.** Each one bundles an index, an embedding model, and\n",
+    "optionally a traversal query behind a single `search()` method. Swapping `VectorRetriever` for\n",
+    "`HybridCypherRetriever` changes retrieval behaviour without touching the agent around it.\n",
+    "\n",
+    "**Pair the embedding model with the index deliberately.** A mismatch does not raise an error, it\n",
+    "just returns quietly useless results. Check dimensions, and re-embed a stored chunk to confirm the\n",
+    "models agree.\n",
+    "\n",
+    "**`VectorCypherRetriever` is where the graph earns its place.** Vector search finds a chunk; the\n",
+    "`retrieval_query` walks outward to articles, organizations, and relationships. The model receives\n",
+    "text plus checkable structure in one round trip.\n",
+    "\n",
+    "**Hybrid search covers what embeddings miss.** Semantic similarity is weak on proper nouns and\n",
+    "codes. Running vector and full-text together costs little and recovers the exact matches.\n",
+    "\n",
+    "**ADK turns retrieval strategies into a decision.** Wrapped as tools, several retrievers become\n",
+    "options an agent selects between per question — and their docstrings are the entire control\n",
+    "surface.\n",
+    "\n",
+    "### Next steps\n",
+    "\n",
+    "* [GraphRAG user guide](https://neo4j.com/docs/neo4j-graphrag-python/current/user_guide_rag.html) —\n",
+    "  `Text2CypherRetriever`, `ToolsRetriever`, and the `GraphRAG` generation pipeline\n",
+    "* [Knowledge graph builder](https://neo4j.com/docs/neo4j-graphrag-python/current/user_guide_kg_builder.html) —\n",
+    "  `SimpleKGPipeline` for building a graph from unstructured documents\n",
+    "* [API reference](https://neo4j.com/docs/neo4j-graphrag-python/current/api.html) — every retriever,\n",
+    "  embedder, and LLM interface\n",
+    "* [ADK graph workflows](https://adk.dev/graphs/) — fixing the retrieval strategy instead of letting\n",
+    "  the agent choose"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION

Adds a second notebook showing `neo4j-graphrag` retrievers wired into a Google ADK agent, covering the semantic retrieval gap the MCP notebook doesn't reach.

### New: `neo4j_graphrag_adk.ipynb`

**Index/embedder pairing** — how to pick a vector index and confirm the embedding model matches it (a mismatch returns meaningless results without erroring)
**`VectorRetriever`** — semantic search over article chunks
**`VectorCypherRetriever`** — vector search that continues into the graph, returning each passage with its source article, date, sentiment, and related companies
**`HybridRetriever`** — vector plus full-text, recovering exact matches on names and tickers that embeddings miss
**Retrievers as ADK tools** — three strategies exposed via `FunctionTool`, selected by the agent per question


Runs against the public `companies` demo database. Needs a Gemini API key; embeddings run locally via sentence-transformers.

### README

Overview extended to four integration patterns
New Key Feature and install line for the GraphRAG examples
New snippet: `HybridCypherRetriever` wrapped as an ADK tool
Notebook added to the Example table, `neo4j-graphrag` docs added to Resources